### PR TITLE
Fix linker error when building threadpool_test on Linux

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -442,7 +442,7 @@ void Map::LoadArena()
 
 bool Map::Load()
 {
-	char namebuf[6];
+	char namebuf[7];
 
 	if (this->id < 0)
 	{
@@ -2434,7 +2434,7 @@ bool Map::Evacuate()
 
 bool Map::Reload()
 {
-	char namebuf[6];
+	char namebuf[7];
 	char checkrid[4];
 
 	std::string filename = this->world->config["MapDir"];

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -323,7 +323,7 @@ Quest::Quest(short id, World* world)
 
 void Quest::Load()
 {
-	char namebuf[6];
+	char namebuf[7];
 
 	std::string filename = this->world->config["QuestDir"];
 	std::sprintf(namebuf, "%05i", this->id);

--- a/src/test/util/threadpool_test.cpp
+++ b/src/test/util/threadpool_test.cpp
@@ -275,7 +275,7 @@ GTEST_TEST(ThreadPoolTests, ShutdownPreventsStateChanges)
     testThreadPool.QueueWork(workFunc, nullptr);
     testThreadPool.Shutdown();
 
-    ASSERT_THROW(testThreadPool.QueueWork([](const void * state) { }, nullptr), std::runtime_error) << "Expected exception when queuing ThreadPool work during shutdown";
+    ASSERT_THROW(testThreadPool.QueueWork([](const void * state) { (void)state; }, nullptr), std::runtime_error) << "Expected exception when queuing ThreadPool work during shutdown";
     ASSERT_THROW(testThreadPool.SetNumThreads(defaultMaxThreads + 1), std::runtime_error) << "Expected exception when resizing ThreadPool during shutdown";
     ASSERT_NO_THROW(testThreadPool.SetNumThreads(defaultMaxThreads)) << "Expected no exception when setting same number of threads during shutdown";
 

--- a/src/util/threadpool.cpp
+++ b/src/util/threadpool.cpp
@@ -8,6 +8,11 @@
 
 namespace util
 {
+    // These are initialized here to allow tests to compile on Ubuntu Linux (g++ 7.4.0)
+    // Otherwise, they aren't in the object file in unity build mode and test linking fails
+    const size_t ThreadPool::MAX_THREADS = 32;
+    const size_t ThreadPool::DEFAULT_THREADS = 4;
+
     // There should really only be a single thread pool per application
     static ThreadPool threadPoolInstance;
 

--- a/src/util/threadpool.hpp
+++ b/src/util/threadpool.hpp
@@ -37,8 +37,8 @@ namespace util
         ThreadPool(ThreadPool&&) = delete;
         virtual ~ThreadPool();
 
-        static constexpr size_t MAX_THREADS = 32;
-        static constexpr size_t DEFAULT_THREADS = 4;
+        static const size_t MAX_THREADS;
+        static const size_t DEFAULT_THREADS;
 
     private:
         typedef std::pair<const WorkFunc, const void*> WorkFuncWithState;


### PR DESCRIPTION
Tests in threadpool failed to link due to static constexpr definitions in the header file. Not sure why this worked in msbuild but not gcc.

Also fixed a couple warnings using sprintf when building on Linux.