### PR TITLE
Fix linking mariadb on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ if(WIN32)
 	list(APPEND eoserv_LIBRARIES winmm ws2_32)
 
 	if (EOSERV_WANT_MYSQL)
-		list(APPEND eoserv_LIBRARIES shlwapi)
+		list(APPEND eoserv_LIBRARIES shlwapi crypt32 secur32)
 	endif()
 else()
 	list(APPEND eoserv_LIBRARIES pthread)


### PR DESCRIPTION
Building on windows fails on my machine when linking against MariaDB unless `crypt32` and `secur32` are included.

This PR adds `crypt32` and `secur32` to `eoserv_LIBRARIES` when linking against MariaDB on windows.