### PR TITLE
Use tabs for indentation in C++ source code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 # Override Defaults
 [*.sh]
 indent_size = 2
+
+[*.{c,h,cpp,hpp}]
+indent_style = tab


### PR DESCRIPTION
EOSERV uses tabs rather than spaces in C++ source code.
The `.editorconfig` file specifies `indent_style = space`. This gets picked up by Visual Studio and leads to mixed spaces and tabs.

This PR overrides the `indent_style` for C++ source code files.