### PR TITLE
Add CI build support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 *.ico filter=lfs diff=lfs merge=lfs -text
+*.eif filter=lfs diff=lfs merge=lfs -text
+*.ecf filter=lfs diff=lfs merge=lfs -text
+*.esf filter=lfs diff=lfs merge=lfs -text
+*.enf filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ETHEOS
 
+[![Build status](https://ethanmoffat.visualstudio.com/EndlessClient/_apis/build/status/ethanmoffat.etheos?branchName=master)](https://ethanmoffat.visualstudio.com/EndlessClient/_build/latest?definitionId=12&branchName=master)
+
 ## Table of Contents
 
 - [Getting Started on Windows](#getting-started-on-windows)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The dependencies for building ETHEOS on Windows are:
 - CMake (>= 2.6)
 - SQLite
 - MariaDB
+- vswhere
 - git (for getting bcrypt/googletest components)
 
 #### Automatic Dependency Installation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,10 +34,17 @@ stages:
       displayName: 'Install build dependencies'
       inputs:
         filePath: '.\scripts\install-deps.ps1'
-    - script: ./build-windows.ps1 -Clean
+        arguments: '-SkipCMake' # CMake is installed on the windows-latest image
+    - task: PowerShell@2
       displayName: 'Build'
-    - script: ./build-linux.sh -Test
+      inputs:
+        filePath: './build-windows.ps1'
+        arguments: '-Clean'
+    - task: PowerShell@2
       displayName: 'Test'
+      inputs:
+        filePath: './build-windows.ps1'
+        arguments: '-Test'
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: 'install'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,8 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
+    - checkout: self
+      lfs: true
     - script: sudo ./install-deps.sh
       displayName: 'Install build dependencies'
       workingDirectory: 'scripts'
@@ -30,6 +32,8 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
+    - checkout: self
+      lfs: true
     - task: PowerShell@2
       displayName: 'Install build dependencies'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,8 +33,7 @@ stages:
     - task: PowerShell@2
       displayName: 'Install build dependencies'
       inputs:
-        filePath: '.\install-deps.ps1'
-        workingDirectory: 'scripts'
+        filePath: '.\scripts\install-deps.ps1'
     - script: ./build-windows.ps1 -Clean
       displayName: 'Build'
     - script: ./build-linux.sh -Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,44 @@
+name: 0.7.0:$(rev:rrrr)
+
+trigger:
+- master
+
+stages:
+- stage: build_test
+  displayName: 'Build + Test'
+  jobs:
+  - job:
+    displayName: 'Build - Ubuntu'
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - script: sudo ./install-deps.sh
+      displayName: 'Install build dependencies'
+      workingDirectory: 'scripts'
+    - script: ./build-linux.sh -c -i
+      displayName: 'Build'
+    - script: ./build-linux.sh -t
+      displayName: 'Test'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: 'install'
+        ArtifactName: 'drop'
+        publishLocation: 'Container'
+
+  - job:
+    displayName: 'Build - Windows'
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - script: .\install-deps.ps1
+      displayName: 'Install build dependencies'
+      workingDirectory: 'scripts'
+    - script: ./build-windows.ps1 -Clean
+      displayName: 'Build'
+    - script: ./build-linux.sh -Test
+      displayName: 'Test'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: 'install'
+        ArtifactName: 'drop'
+        publishLocation: 'Container'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,12 +43,12 @@ stages:
       displayName: 'Build'
       inputs:
         filePath: './build-windows.ps1'
-        arguments: '-Clean'
+        arguments: '-Clean -x64' # x64 required on build machines for MySQL library compatibility
     - task: PowerShell@2
       displayName: 'Test'
       inputs:
         filePath: './build-windows.ps1'
-        arguments: '-Test'
+        arguments: '-Test -x64'
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: 'install'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: 0.7.0:$(rev:rrrr)
+name: 0.7.0.$(rev:rrrr)
 
 trigger:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,9 +30,11 @@ stages:
     pool:
       vmImage: 'windows-latest'
     steps:
-    - script: .\install-deps.ps1
+    - task: PowerShell@2
       displayName: 'Install build dependencies'
-      workingDirectory: 'scripts'
+      inputs:
+        filePath: '.\install-deps.ps1'
+        workingDirectory: 'scripts'
     - script: ./build-windows.ps1 -Clean
       displayName: 'Build'
     - script: ./build-linux.sh -Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ stages:
     - script: sudo ./install-deps.sh
       displayName: 'Install build dependencies'
       workingDirectory: 'scripts'
-    - script: ./build-linux.sh -c -i
+    - script: ./build-linux.sh -c --sqlserver ON --mariadb ON
       displayName: 'Build'
     - script: ./build-linux.sh -t
       displayName: 'Test'
@@ -43,12 +43,12 @@ stages:
       displayName: 'Build'
       inputs:
         filePath: './build-windows.ps1'
-        arguments: '-Clean -x64' # x64 required on build machines for MySQL library compatibility
+        arguments: '-Clean'
     - task: PowerShell@2
       displayName: 'Test'
       inputs:
         filePath: './build-windows.ps1'
-        arguments: '-Test -x64'
+        arguments: '-Test'
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: 'install'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ stages:
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: 'install'
-        ArtifactName: 'drop'
+        ArtifactName: 'linux'
         publishLocation: 'Container'
 
   - job:
@@ -53,5 +53,5 @@ stages:
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: 'install'
-        ArtifactName: 'drop'
+        ArtifactName: 'windows'
         publishLocation: 'Container'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: 0.7.0.$(rev:rrrr)
+name: 0.7.1.$(rev:rrrr)
 
 trigger:
 - master
@@ -8,7 +8,7 @@ stages:
   displayName: 'Build + Test'
   jobs:
   - job:
-    displayName: 'Build - Ubuntu'
+    displayName: 'Build - Release - Ubuntu (MariaDB + SQL Server)'
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -17,10 +17,11 @@ stages:
     - script: sudo ./install-deps.sh
       displayName: 'Install build dependencies'
       workingDirectory: 'scripts'
-    - script: ./build-linux.sh -c --sqlserver ON --mariadb ON
+    - script: ./build-linux.sh -c --sqlserver ON --mariadb ON --sqlite ON
       displayName: 'Build'
-    - script: ./build-linux.sh -t
+    - script: ./eoserv_test
       displayName: 'Test'
+      workingDirectory: $(Build.SourcesDirectory)/install/test
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: 'install'
@@ -28,7 +29,7 @@ stages:
         publishLocation: 'Container'
 
   - job:
-    displayName: 'Build - Windows'
+    displayName: 'Build - Release - Windows (MariaDB + SQL Server)'
     pool:
       vmImage: 'windows-latest'
     steps:
@@ -42,13 +43,13 @@ stages:
     - task: PowerShell@2
       displayName: 'Build'
       inputs:
-        filePath: './build-windows.ps1'
+        filePath: '.\build-windows.ps1'
         arguments: '-Clean'
     - task: PowerShell@2
       displayName: 'Test'
       inputs:
-        filePath: './build-windows.ps1'
-        arguments: '-Test'
+        filePath: '.\eoserv_test.exe'
+        workingDirectory: $(Build.SourcesDirectory)\install\test
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: 'install'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,11 +45,9 @@ stages:
       inputs:
         filePath: '.\build-windows.ps1'
         arguments: '-Clean'
-    - task: PowerShell@2
+    - script: .\eoserv_test.exe
       displayName: 'Test'
-      inputs:
-        filePath: '.\eoserv_test.exe'
-        workingDirectory: $(Build.SourcesDirectory)\install\test
+      workingDirectory: $(Build.SourcesDirectory)\install\test
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: 'install'

--- a/build-windows.ps1
+++ b/build-windows.ps1
@@ -84,8 +84,9 @@ if (-not ($env:PATH -match [System.Text.RegularExpressions.Regex]::Escape($vsIns
 }
 
 # For building on Windows, force precompiled headers off
+# TODO: make dbengines configurable with script parameters
 #
-cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -DCMAKE_GENERATOR_PLATFORM=Win32 -G $generator ..
+cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_WANT_MYSQL=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -DCMAKE_GENERATOR_PLATFORM=Win32 -G $generator ..
 cmake --build . --config $buildMode --target INSTALL --
 $tmpResult=$?
 if (-not $tmpResult)

--- a/build-windows.ps1
+++ b/build-windows.ps1
@@ -84,9 +84,9 @@ if (-not ($env:PATH -match [System.Text.RegularExpressions.Regex]::Escape($vsIns
 }
 
 # For building on Windows, force precompiled headers off
-# TODO: make dbengines configurable with script parameters
+# TODO: make db engines configurable with script parameters
 #
-cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_WANT_MYSQL=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -DCMAKE_GENERATOR_PLATFORM=Win32 -G $generator ..
+cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_WANT_MYSQL=ON -DEOSERV_WANT_SQLITE=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -DCMAKE_GENERATOR_PLATFORM=Win32 -G $generator ..
 cmake --build . --config $buildMode --target INSTALL --
 $tmpResult=$?
 if (-not $tmpResult)

--- a/build-windows.ps1
+++ b/build-windows.ps1
@@ -2,6 +2,7 @@ param (
     [switch]$Clean,
     [switch]$Debug,
     [switch]$Test,
+    [switch]$x64,
     $BuildDir = "build"
 )
 
@@ -82,11 +83,16 @@ if (-not ($env:PATH -match [System.Text.RegularExpressions.Regex]::Escape($vsIns
     [System.Environment]::SetEnvironmentVariable("PATH", "$vsInstallPath;$env:PATH", [System.EnvironmentVariableTarget]::Process)
 }
 
+if ($x64) {
+    $platform="x64"
+} else {
+    $platform="Win32"
+}
+
 # For building on Windows, force sqlite3 off until we get better dependency management (TODO: dependency management)
 # For building on Windows, force precompiled headers off
-# For building on Windows, force x86
 #
-cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -DCMAKE_GENERATOR_PLATFORM=Win32 -G $generator ..
+cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -DCMAKE_GENERATOR_PLATFORM=$platform -G $generator ..
 cmake --build . --config $buildMode --target INSTALL --
 $tmpResult=$?
 if (-not $tmpResult)

--- a/build-windows.ps1
+++ b/build-windows.ps1
@@ -84,8 +84,9 @@ if (-not ($env:PATH -match [System.Text.RegularExpressions.Regex]::Escape($vsIns
 
 # For building on Windows, force sqlite3 off until we get better dependency management (TODO: dependency management)
 # For building on Windows, force precompiled headers off
+# For building on Windows, force x86
 #
-cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -G $generator ..
+cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -DCMAKE_GENERATOR_PLATFORM=Win32 -G $generator ..
 cmake --build . --config $buildMode --target INSTALL --
 $tmpResult=$?
 if (-not $tmpResult)

--- a/build-windows.ps1
+++ b/build-windows.ps1
@@ -92,7 +92,7 @@ if ($x64) {
 # For building on Windows, force sqlite3 off until we get better dependency management (TODO: dependency management)
 # For building on Windows, force precompiled headers off
 #
-cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -DCMAKE_GENERATOR_PLATFORM=$platform -G $generator ..
+cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF "-DCMAKE_GENERATOR_PLATFORM=$platform" -G $generator ..
 cmake --build . --config $buildMode --target INSTALL --
 $tmpResult=$?
 if (-not $tmpResult)

--- a/cmake/FindMariaDB.cmake
+++ b/cmake/FindMariaDB.cmake
@@ -22,6 +22,7 @@
 
 find_path(MARIADB_INCLUDE_DIR
 	NAMES mysql.h
+	PATHS "C:/Program Files (x86)/MariaDB/MariaDB Connector C/include"
 	PATH_SUFFIXES
 		mariadb
 		mysql
@@ -29,6 +30,7 @@ find_path(MARIADB_INCLUDE_DIR
 
 find_library(MARIADB_LIBRARY
 	NAMES mariadbclient mariadb mysqlclient mysql
+	PATHS "C:/Program Files (x86)/MariaDB/MariaDB Connector C/lib"
 )
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -239,12 +239,12 @@ set(DataFiles
 	data/speech.ini
 )
 
-# No default set of pub files is available yet.
+# These empty pub files are required for some tests
 set(PubFiles
-#	data/pub/dat001.eif
-#	data/pub/dtn001.enf
-#	data/pub/dsl001.esf
-#	data/pub/dat001.ecf
+	data/pub/empty.eif
+	data/pub/empty.enf
+	data/pub/empty.esf
+	data/pub/empty.ecf
 )
 
 # No default set of map files is available yet.

--- a/data/pub/empty.ecf
+++ b/data/pub/empty.ecf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d1278d0aa7c7d721646d844f26d819438d75dfa3e881c83eefc6c7fdb2bee38
+size 28

--- a/data/pub/empty.eif
+++ b/data/pub/empty.eif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1710f3a0243d83a921c416145b5cf7f1ce770b7dcfe3f8677b70ad45a19e1735
+size 135

--- a/data/pub/empty.enf
+++ b/data/pub/empty.enf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3c66d5ab5d063f60820adca996f832a78174e19a6dcca88742471da2e668bcd
+size 53

--- a/data/pub/empty.esf
+++ b/data/pub/empty.esf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2479c107beeef749b2884701f165ea05b467e9251956bec2a19de8efb8117dc
+size 66

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -66,11 +66,12 @@ if (-not $SkipMariaDB) {
 
     # Update the path with the new directory
     # This is a fixed default value of the MSI that is downloaded
+    #
     $InstallDir="C:\Program Files (x86)\MariaDB\MariaDB Connector C\lib"
     $PATHRegKey = 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment'
     $Old_Path=(Get-ItemProperty -Path $PATHRegKey -Name Path).Path
     if ($Old_Path.IndexOf($InstallDir, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
-        Set-ItemProperty -Path $PATHRegKey -Name PATH -Value ("$Old_Path;$InstallDir")
+        Set-ItemProperty -Path $PATHRegKey -Name PATH -Value ("$InstallDir;$Old_Path")
     }
 
     refreshenv
@@ -91,6 +92,7 @@ if (-not $SkipSQLite) {
     $LocalSqliteDir = Resolve-Path $LocalSqliteDir
 
     # This is a guaranteed download location due to OSS Chocolatey restrictions
+    #
     $ChocoSqliteInstallDir = "C:\ProgramData\chocolatey\lib\sqlite\tools"
     foreach ($item in ((Get-ChildItem -Force -Recurse $ChocoSqliteInstallDir | Where-Object {$_.Name -like '*.dll'}))) {
         Copy-Item -Force $item.FullName (Join-Path $LocalSqliteDir "bin")
@@ -99,6 +101,7 @@ if (-not $SkipSQLite) {
     $DownloadedFile = (Join-Path $DownloadDir "sqlite3.zip")
     try {
         # This throws for some reason but still downloads the file?
+        #
         (New-Object System.Net.WebClient).DownloadFile($Sqlite3URL, $DownloadedFile)
         $zip = [IO.Compression.ZipFile]::OpenRead($DownloadedFile)
 

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -125,3 +125,13 @@ if (-not $SkipSQLite) {
 if ((Test-Path $DownloadDir)) {
     Remove-Item $DownloadDir -Recurse -Force
 }
+
+if (-not (Get-Command vswhere)) {
+    Write-Output "Installing vswhere..."
+    choco install -y vswhere | Out-Null
+
+    refreshenv
+    if (-not (Get-Command vswhere)) {
+        Write-Warning "Could not detect vswhere after install. Shell may need to be restarted."
+    }
+}

--- a/src/database.hpp
+++ b/src/database.hpp
@@ -34,7 +34,7 @@ class Database_Exception : public std::exception
 		Database_Exception(const char *e, int errorCode = -1) : err(e), errorCode(errorCode) {};
 		const char *error() const noexcept { return err; };
 		virtual const char *what() const noexcept { return "Database_Exception"; }
-		const int getErrorCode() const noexcept { return errorCode; }
+		int getErrorCode() const noexcept { return errorCode; }
 };
 
 /**

--- a/src/test/testhelper/mocks.hpp
+++ b/src/test/testhelper/mocks.hpp
@@ -42,7 +42,4 @@ class MockDatabaseFactory : public DatabaseFactory
 {
 public:
     MOCK_METHOD(std::shared_ptr<Database>, CreateDatabase, (Config& config, bool logConnection), (const override));
-
-private:
-    MockDatabase * database;
 };

--- a/src/test/testhelper/setup.hpp
+++ b/src/test/testhelper/setup.hpp
@@ -11,10 +11,10 @@ static void CreateConfigWithTestDefaults(Config& config, Config& admin_config)
     // these are needed for the test to run
     // test assumes relative to directory {install_dir}/test
     config["ServerLanguage"] = "../lang/en.ini";
-    config["EIF"] = "../data/pub/dat001.eif";
-    config["ENF"] = "../data/pub/dtn001.enf";
-    config["ESF"] = "../data/pub/dsl001.esf";
-    config["ECF"] = "../data/pub/dat001.ecf";
+    config["EIF"] = "../data/pub/empty.eif";
+    config["ENF"] = "../data/pub/empty.enf";
+    config["ESF"] = "../data/pub/empty.esf";
+    config["ECF"] = "../data/pub/empty.ecf";
 
     //turn off SLN
     config["SLN"] = "false";


### PR DESCRIPTION
- Support for multiple versions of Visual Studio and detection via vswhere (added to install-deps script)
- Build pipeline that builds release mode for Windows and Linux
- Forced support for all database engines in build pipeline
- Empty pub files copied by default to ensure tests pass on a clean system with no pub files installed