### PR TITLE
Fix unit tests on fast pcs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ option(EOSERV_NO_DATA "Disables copying of data files in to build directory" OFF
 
 option(EOSERV_DEBUG_QUERIES "Enables printing of database queries to debug output" OFF)
 
-option(EOSERV_OFFLINE_BUILD "Enables build when working offline (no internet connection)" OFF)
+option(EOSERV_OFFLINE "Enables build when working offline (no internet connection)" OFF)
 
 # --------------
 #  Source files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ option(EOSERV_NO_DATA "Disables copying of data files in to build directory" OFF
 
 option(EOSERV_DEBUG_QUERIES "Enables printing of database queries to debug output" OFF)
 
+option(EOSERV_OFFLINE_BUILD "Enables build when working offline (no internet connection)" OFF)
+
 # --------------
 #  Source files
 # --------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,17 @@
 name: 0.7.1.$(rev:rrrr)
 
 trigger:
-- master
+  branches:
+    include:
+    - master
+
+schedules:
+- cron: 0 0 * * 0 # 0 - hour | 0 - minute | * - any day | * - any month | 0 - sunday
+  displayName: 'Scheduled Build'
+  branches:
+    include:
+      - master
+  always: true
 
 stages:
 - stage: build_test

--- a/build-windows.ps1
+++ b/build-windows.ps1
@@ -2,6 +2,7 @@ param (
     [switch]$Clean,
     [switch]$Debug,
     [switch]$Test,
+    [switch]$Offline,
     $BuildDir = "build"
 )
 
@@ -56,7 +57,11 @@ if ($Debug) {
     $buildMode = "Release"
 }
 
-cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF -G "Visual Studio 15 2017" ..
+if ($Offline) {
+    $OfflineFlag="-DEOSERV_OFFLINE=ON"
+}
+
+cmake -DEOSERV_WANT_SQLSERVER=ON -DEOSERV_USE_PRECOMPILED_HEADERS=OFF $OfflineFlag -G "Visual Studio 15 2017" ..
 $tmpResult=$?
 if (-not $tmpResult)
 {

--- a/cmake/DownloadBcrypt.cmake
+++ b/cmake/DownloadBcrypt.cmake
@@ -1,21 +1,21 @@
 
 # Download and unpack bcrypt at configure time
-if (NOT ${EOSERV_OFFLINE})
+if (NOT EOSERV_OFFLINE)
   configure_file(${CMAKE_SOURCE_DIR}/cmake/bcryptproj.cmake bcrypt-download/CMakeLists.txt)
-endif()
 
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bcrypt-download )
-if(result)
-  message(FATAL_ERROR "CMake step for bcrypt failed: ${result}")
-endif()
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bcrypt-download )
+  if(result)
+    message(FATAL_ERROR "CMake step for bcrypt failed: ${result}")
+  endif()
 
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bcrypt-download )
-if(result)
-  message(FATAL_ERROR "Build step for bcrypt failed: ${result}")
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bcrypt-download )
+  if(result)
+    message(FATAL_ERROR "Build step for bcrypt failed: ${result}")
+  endif()
 endif()
 
 # Add bcrypt directly to our build. This defines

--- a/cmake/DownloadBcrypt.cmake
+++ b/cmake/DownloadBcrypt.cmake
@@ -1,6 +1,8 @@
 
 # Download and unpack bcrypt at configure time
-configure_file(${CMAKE_SOURCE_DIR}/cmake/bcryptproj.cmake bcrypt-download/CMakeLists.txt)
+if (NOT ${EOSERV_OFFLINE})
+  configure_file(${CMAKE_SOURCE_DIR}/cmake/bcryptproj.cmake bcrypt-download/CMakeLists.txt)
+endif()
 
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
   RESULT_VARIABLE result

--- a/cmake/DownloadGoogleTest.cmake
+++ b/cmake/DownloadGoogleTest.cmake
@@ -1,20 +1,21 @@
 
 # Download and unpack googletest at configure time
-if (NOT ${EOSERV_OFFLINE})
+if (NOT EOSERV_OFFLINE)
   configure_file(${CMAKE_SOURCE_DIR}/cmake/gtestproj.cmake googletest-download/CMakeLists.txt)
-endif()
 
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
-endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+  endif()
+
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  endif()
 endif()
 
 # Prevent overriding the parent project's compiler/linker

--- a/cmake/DownloadGoogleTest.cmake
+++ b/cmake/DownloadGoogleTest.cmake
@@ -1,6 +1,9 @@
 
 # Download and unpack googletest at configure time
-configure_file(${CMAKE_SOURCE_DIR}/cmake/gtestproj.cmake googletest-download/CMakeLists.txt)
+if (NOT ${EOSERV_OFFLINE})
+  configure_file(${CMAKE_SOURCE_DIR}/cmake/gtestproj.cmake googletest-download/CMakeLists.txt)
+endif()
+
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
   RESULT_VARIABLE result
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )

--- a/src/test/handlers/Login_test.cpp
+++ b/src/test/handlers/Login_test.cpp
@@ -407,6 +407,6 @@ GTEST_TEST(LoginTests, LoginWithOldPasswordVersionUpgradesInBackground)
         r.GetShort(); // skip first two bytes (Family/Action - packet id, normally consumed from the reader when selecting the handler)
         Handlers::Login_Request(client.get(), r);
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1500));
     }
 }


### PR DESCRIPTION
- Add offline build option for building with no internet connection (requires dependencies to be downloaded, including gtest and bcrypt)
- Add weekly scheduled build
- Increase timeout for a Login test so fast PCs don't clean up test before it finishes running
- Add counting semaphore for a ThreadPool test to ensure test only terminates when it is actually done