### PR TITLE
Add support for automatic dump/restore of world. Remove long-running open database transaction.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 install/
 scripts/download/
 sqlite/
+json/
 
 gtest-download/*
 !gtest-download/CMakeLists.txt.in

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -56,6 +56,31 @@
             "intelliSenseMode": "msvc-x64"
         },
         {
+            "name": "Sqlite - Windows",
+            "includePath": [
+                "build/googletest-src/googletest/include",
+                "build/googletest-src/googlemock/include",
+                "build/bcrypt-src/include",
+                "sqlite/include",
+                "src"
+            ],
+            "defines": [
+                "DATABASE_SQLITE",
+                "_WIN32" // defining _WIN32 here so intellisense works as expected
+            ],
+            "compilerPath": "\"${myCompilerPath}cl.exe\"",
+            "cStandard": "c11",
+            "cppStandard": "c++11",
+            "browse": {
+                "path": [
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "intelliSenseMode": "msvc-x64"
+        },
+        {
             "name": "SqlServer - Linux",
             "includePath": [
                 "build/googletest-src/googletest/include",
@@ -89,6 +114,29 @@
             "defines": [
                 "DATABASE_SQLSERVER",
                 "DATABASE_MYSQL"
+            ],
+            "compilerPath": "/usr/bin/g++",
+            "cStandard": "c11",
+            "cppStandard": "c++11",
+            "browse": {
+                "path": [
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "intelliSenseMode": "gcc-x64"
+        },
+        {
+            "name": "Sqlite - Linux",
+            "includePath": [
+                "build/googletest-src/googletest/include",
+                "build/googletest-src/googlemock/include",
+                "build/bcrypt-src/include",
+                "src"
+            ],
+            "defines": [
+                "DATABASE_SQLITE"
             ],
             "compilerPath": "/usr/bin/g++",
             "cStandard": "c11",
@@ -154,6 +202,32 @@
             "intelliSenseMode": "msvc-x64"
         },
         {
+            "name": "Sqlite - Windows (Debug)",
+            "includePath": [
+                "build/googletest-src/googletest/include",
+                "build/googletest-src/googlemock/include",
+                "build/bcrypt-src/include",
+                "sqlite/include",
+                "src"
+            ],
+            "defines": [
+                "DATABASE_SQLITE",
+                "DEBUG",
+                "_WIN32" // defining _WIN32 here so intellisense works as expected
+            ],
+            "compilerPath": "\"${myCompilerPath}cl.exe\"",
+            "cStandard": "c11",
+            "cppStandard": "c++11",
+            "browse": {
+                "path": [
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "intelliSenseMode": "msvc-x64"
+        },
+        {
             "name": "SqlServer - Linux (Debug)",
             "includePath": [
                 "build/googletest-src/googletest/include",
@@ -188,6 +262,30 @@
             "defines": [
                 "DATABASE_SQLSERVER",
                 "DATABASE_MYSQL",
+                "DEBUG"
+            ],
+            "compilerPath": "/usr/bin/g++",
+            "cStandard": "c11",
+            "cppStandard": "c++11",
+            "browse": {
+                "path": [
+                    "${workspaceFolder}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "intelliSenseMode": "gcc-x64"
+        },
+        {
+            "name": "Sqlite - Linux (Debug)",
+            "includePath": [
+                "build/googletest-src/googletest/include",
+                "build/googletest-src/googlemock/include",
+                "build/bcrypt-src/include",
+                "src"
+            ],
+            "defines": [
+                "DATABASE_SQLITE",
                 "DEBUG"
             ],
             "compilerPath": "/usr/bin/g++",

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -12,6 +12,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -36,6 +37,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -62,6 +64,7 @@
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
                 "sqlite/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -86,6 +89,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -109,6 +113,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -133,6 +138,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -156,6 +162,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -181,6 +188,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -208,6 +216,7 @@
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
                 "sqlite/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -233,6 +242,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -257,6 +267,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [
@@ -282,6 +293,7 @@
                 "build/googletest-src/googletest/include",
                 "build/googletest-src/googlemock/include",
                 "build/bcrypt-src/include",
+                "json",
                 "src"
             ],
             "defines": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,13 @@
             "args": [
                 "-command",
                 ".\\build-windows.ps1",
-                "-Debug"
+                "-Debug",
+                "-SqlServer",
+                "ON",
+                "-MariaDB",
+                "ON",
+                "-Sqlite",
+                "ON"
             ],
             "group": "build",
             "presentation": {
@@ -23,6 +29,12 @@
             "args": [
                 "-command",
                 ".\\build-windows.ps1",
+                "-SqlServer",
+                "ON",
+                "-MariaDB",
+                "ON",
+                "-Sqlite",
+                "ON"
             ],
             "group": "build",
             "presentation": {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ add_library(eoserv_lib STATIC ${eoserv_SOURCE_FILES})
 add_executable(eoserv ${eoserv_MAIN_FILES})
 add_executable(eoserv_test ${TestFiles})
 
-target_include_directories(eoserv_test PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(eoserv_test PUBLIC ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/json)
 target_include_directories(eoserv_test PUBLIC ${CMAKE_BINARY_DIR}/googletest-src/googlemock/include)
 target_link_libraries(eoserv_test gtest_main gmock eoserv_lib)
 
@@ -242,6 +242,8 @@ include(DownloadBcrypt)
 target_include_directories(eoserv PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
 target_include_directories(eoserv_lib PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
 list(APPEND eoserv_LIBRARIES bcrypt)
+
+target_include_directories(eoserv PUBLIC ${CMAKE_SOURCE_DIR}/json)
 
 target_link_libraries(eoserv eoserv_lib)
 target_link_libraries(eoserv_lib ${eoserv_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,7 @@ target_include_directories(eoserv PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
 target_include_directories(eoserv_lib PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
 list(APPEND eoserv_LIBRARIES bcrypt)
 
-target_include_directories(eoserv PUBLIC ${CMAKE_SOURCE_DIR}/json)
+target_include_directories(eoserv_lib PUBLIC ${CMAKE_SOURCE_DIR}/json)
 
 target_link_libraries(eoserv eoserv_lib)
 target_link_libraries(eoserv_lib ${eoserv_LIBRARIES})

--- a/cmake/SourceFileList.cmake
+++ b/cmake/SourceFileList.cmake
@@ -275,6 +275,7 @@ set(ExtraFiles
 
 set(TestFiles
 	src/test/config_test.cpp
+	src/test/worlddump_test.cpp
 	src/test/handlers/Login_test.cpp
 	src/test/util/semaphore_test.cpp
 	src/test/util/threadpool_test.cpp

--- a/config/server.ini
+++ b/config/server.ini
@@ -151,3 +151,7 @@ InitLoginBan = yes
 # Number of background threads in the thread pool
 # A value of 0 defaults to the number of concurrent threads supported by the implementation
 ThreadPoolThreads = 0
+
+## WorldDumpFile (string)
+# Path to a file used as a json dump for the world when the server crashes or exits
+WorldDumpFile = ./world.bak.json

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -125,10 +125,6 @@ if (-not $SkipSQLite) {
     CheckPathForDll -DllName "sqlite3.dll" -AdditionalPaths "$LocalSqliteDir\bin"
 }
 
-if ((Test-Path $DownloadDir)) {
-    Remove-Item $DownloadDir -Recurse -Force
-}
-
 if (-not (Get-Command vswhere)) {
     Write-Output "Installing vswhere..."
     choco install -y vswhere | Out-Null
@@ -137,4 +133,23 @@ if (-not (Get-Command vswhere)) {
     if (-not (Get-Command vswhere)) {
         Write-Warning "Could not detect vswhere after install. Shell may need to be restarted."
     }
+}
+
+$JSON_VERSION="3.9.1"
+if (-not (Test-Path (Join-Path $PSScriptRoot "..\json"))) {
+    New-Item -ItemType Directory -Path (Join-Path $PSScriptRoot "..\json")
+
+    $JsonUrl="https://raw.githubusercontent.com/nlohmann/json/v$JSON_VERSION/single_include/nlohmann/json.hpp"
+    $DownloadedFile=(Join-Path $DownloadDir "json.hpp")
+    (New-Object System.Net.WebClient).DownloadFile($JsonUrl, $DownloadedFile)
+
+    if (-not (Test-Path $DownloadedFile)) {
+        Write-Error "Error downloading JSON library"
+    } else {
+        Copy-Item $DownloadedFile (Join-Path $PSScriptRoot "..\json")
+    }
+}
+
+if ((Test-Path $DownloadDir)) {
+    Remove-Item $DownloadDir -Recurse -Force
 }

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -134,3 +134,12 @@ if [ "$SKIPCMAKE" == "false" ]; then
     ./cmake-3.16.0-Linux-x86_64.sh --skip-license --prefix=/usr
     rm cmake-3.16.0-Linux-x86_64.sh
 fi
+
+echo "Installing json library dependency"
+
+if [ ! -d ../json ]; then
+    mkdir ../json
+fi
+JSON_VERSION=3.9.1
+wget -q "https://raw.githubusercontent.com/nlohmann/json/v$JSON_VERSION/single_include/nlohmann/json.hpp"
+mv json.hpp ../json

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -353,6 +353,18 @@ template <typename T> static T GetRow(std::unordered_map<std::string, util::vari
 	return row[col];
 }
 
+Character::Character(World * world)
+	: world(world)
+	, online(false)
+	, display_str(this->world->config["UseAdjustedStats"] ? adj_str : str)
+	, display_intl(this->world->config["UseAdjustedStats"] ? adj_intl : intl)
+	, display_wis(this->world->config["UseAdjustedStats"] ? adj_wis : wis)
+	, display_agi(this->world->config["UseAdjustedStats"] ? adj_agi : agi)
+	, display_con(this->world->config["UseAdjustedStats"] ? adj_con : con)
+	, display_cha(this->world->config["UseAdjustedStats"] ? adj_cha : cha)
+{
+}
+
 Character::Character(std::string name, World *world)
 	: muted_until(0)
 	, bot(false)

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -354,8 +354,8 @@ template <typename T> static T GetRow(std::unordered_map<std::string, util::vari
 }
 
 Character::Character(World * world)
-	: world(world)
-	, online(false)
+	: online(false)
+	, world(world)
 	, display_str(this->world->config["UseAdjustedStats"] ? adj_str : str)
 	, display_intl(this->world->config["UseAdjustedStats"] ? adj_intl : intl)
 	, display_wis(this->world->config["UseAdjustedStats"] ? adj_wis : wis)

--- a/src/character.hpp
+++ b/src/character.hpp
@@ -280,6 +280,7 @@ class Character : public Command_Source
 		std::set<Character_QuestState> quests_inactive;
 		std::string quest_string;
 
+		Character(World *);
 		Character(std::string name, World *);
 
 		bool IsHideInvisible() const { return hidden & HideInvisible; }

--- a/src/character.hpp
+++ b/src/character.hpp
@@ -95,6 +95,8 @@ std::string SpellSerialize(const std::list<Character_Spell> &list);
  */
 std::list<Character_Spell> SpellUnserialize(const std::string& serialized);
 
+std::string QuestSerialize(const std::map<short, std::shared_ptr<Quest_Context>>& list, const std::set<Character_QuestState>& list_inactive);
+
 /**
  * One type of item in a Characters inventory
  */

--- a/src/database.hpp
+++ b/src/database.hpp
@@ -116,7 +116,6 @@ class Database
 		bool in_transaction;
 		std::list<std::string> transaction_log;
 
-	private:
 		typedef std::pair<std::string, std::list<std::string>> QueryParameterPair;
 		QueryParameterPair ParseQueryArgs(const char * format, va_list ap) const;
 

--- a/src/eoserv_config.cpp
+++ b/src/eoserv_config.cpp
@@ -273,6 +273,7 @@ void eoserv_config_validate_config(Config& config)
 	eoserv_config_default(config, "InitLoginBan"       , true);
 	eoserv_config_default(config, "ThreadPoolThreads"  , 0);
 	eoserv_config_default(config, "AutoCreateDatabase" , false);
+	eoserv_config_default(config, "WorldDumpFile"      , "./world.bak.json");
 }
 
 void eoserv_config_validate_admin(Config& config)

--- a/src/fwd/character.hpp
+++ b/src/fwd/character.hpp
@@ -11,6 +11,7 @@ class Character;
 
 struct Character_Item;
 struct Character_Spell;
+struct Character_QuestState;
 
 enum AdminLevel : unsigned char
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -419,7 +419,6 @@ int eoserv_main(int argc, char *argv[])
 			if (eoserv_sig_abort)
 			{
 				Console::Out("Exiting EOSERV");
-				DumpWorld(server);
 				eoserv_sig_abort = false;
 				break;
 			}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -24,7 +24,16 @@
 #include <unordered_map>
 #include <utility>
 
-Player::Player(std::string username, World * world, Database * database)
+Player::Player(const std::string& username)
+	: username(username)
+{
+	this->online = true;
+	this->character = nullptr;
+	this->client = nullptr;
+	this->login_time = static_cast<int>(std::time(0));
+}
+
+Player::Player(const std::string& username, World * world, Database * database)
 {
 	this->world = world;
 

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -74,7 +74,8 @@ class Player
 
 		std::string dutylast;
 
-		Player(std::string username, World *, Database * = nullptr);
+		Player(const std::string& username);
+		Player(const std::string& username, World *, Database * = nullptr);
 
 		std::vector<Character *> characters;
 		Character *character;

--- a/src/test/handlers/Login_test.cpp
+++ b/src/test/handlers/Login_test.cpp
@@ -251,12 +251,12 @@ GTEST_TEST(LoginTests, LoginWithOldPasswordVersionDoesNotUpgradeOnWrongPassword)
 
     // return password result to login manager for any given username
     EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
-                RawQuery(StartsWith("SELECT `password`, `password_version` FROM `accounts`"), _, _))
+                RawQuery(StartsWith("SELECT password, password_version FROM accounts"), _, _))
         .WillOnce(Return(oldVersionResult));
 
     // Expect no call to update the password
     EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
-                RawQuery(StartsWith("UPDATE `accounts` SET `password` = "), _, _))
+                RawQuery(StartsWith("UPDATE accounts SET password = "), _, _))
         .Times(0);
 
     EOServer server(IPAddress("127.0.0.1"), TestServerPort, mockDatabaseFactory, config, admin_config);
@@ -318,28 +318,28 @@ GTEST_TEST(LoginTests, LoginWithOldPasswordVersionUpgradesInBackground)
 
     // return password result to login manager for any given username
     EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
-                RawQuery(StartsWith("SELECT `password`, `password_version` FROM `accounts`"), _, _))
+                RawQuery(StartsWith("SELECT password, password_version FROM accounts"), _, _))
         .WillOnce(Return(oldVersionResult))
         .WillOnce(Return(newVersionResult));
 
     // return some result to the Player constructor
     EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
-                RawQuery(StartsWith("SELECT `username`, `password` FROM `accounts`"), _, _))
+                RawQuery(StartsWith("SELECT username, password FROM accounts"), _, _))
         .WillRepeatedly(Return(oldVersionResult));
 
     // ensure no characters (characters not needed for test)
     EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
-                RawQuery(HasSubstr("FROM `characters`"), _, _))
+                RawQuery(HasSubstr("FROM characters"), _, _))
         .WillRepeatedly(Return(Database_Result()));
 
     // Expect single call to update the password
     EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
-                RawQuery(StartsWith("UPDATE `accounts` SET `password` = "), _, _))
+                RawQuery(StartsWith("UPDATE accounts SET password = "), _, _))
         .Times(1);
 
     // expect two of these (happens on client disconnect)
     EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
-                RawQuery(StartsWith("UPDATE `accounts` SET `lastused` = "), _, _))
+                RawQuery(StartsWith("UPDATE accounts SET lastused = "), _, _))
         .Times(2);
 
     EOServer server(IPAddress("127.0.0.1"), TestServerPort, mockDatabaseFactory, config, admin_config);

--- a/src/test/testhelper/setup.hpp
+++ b/src/test/testhelper/setup.hpp
@@ -24,7 +24,8 @@ static void CreateConfigWithTestDefaults(Config& config, Config& admin_config)
 
 static std::shared_ptr<Database> CreateMockDatabase()
 {
-    std::shared_ptr<Database> mockDatabase(new MockDatabase);
+    // force SQL server for database mocking stuff
+    std::shared_ptr<Database> mockDatabase(new MockDatabase(Database::Engine::SqlServer));
 
     // set up responses to database queries
     Database_Result banCheckResult;
@@ -39,7 +40,7 @@ static std::shared_ptr<Database> CreateMockDatabase()
 
     // no accounts by default
     EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
-                RawQuery(HasSubstr("FROM `accounts`"), _, _))
+                RawQuery(HasSubstr("FROM accounts"), _, _))
         .WillRepeatedly(Return(Database_Result()));
 
     // Suppress gmock "uninteresting method call" warnings in output

--- a/src/test/testhelper/setup.hpp
+++ b/src/test/testhelper/setup.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <thread>
+
 #include "config.hpp"
 #include "eoserv_config.hpp"
 

--- a/src/test/testhelper/setup.hpp
+++ b/src/test/testhelper/setup.hpp
@@ -21,3 +21,44 @@ static void CreateConfigWithTestDefaults(Config& config, Config& admin_config)
     // turn off timed save
     config["TimedSave"] = "false";
 }
+
+static std::shared_ptr<Database> CreateMockDatabase()
+{
+    std::shared_ptr<Database> mockDatabase(new MockDatabase);
+
+    // set up responses to database queries
+    Database_Result banCheckResult;
+    std::unordered_map<std::string, util::variant> banCheckColumns;
+    banCheckColumns["expires"] = util::variant(-1);
+    banCheckResult.push_back(banCheckColumns);
+
+    // no bans by default
+    EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
+                RawQuery(HasSubstr("FROM bans"), _, _))
+        .WillRepeatedly(Return(banCheckResult));
+
+    // no accounts by default
+    EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()),
+                RawQuery(HasSubstr("FROM `accounts`"), _, _))
+        .WillRepeatedly(Return(Database_Result()));
+
+    // Suppress gmock "uninteresting method call" warnings in output
+    EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()), Pending()).WillRepeatedly(Return(false));
+    EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()), Escape(_)).WillRepeatedly(Return(""));
+    EXPECT_CALL(*dynamic_cast<MockDatabase*>(mockDatabase.get()), Commit()).WillRepeatedly(Return());
+
+    return mockDatabase;
+}
+
+static std::shared_ptr<DatabaseFactory> CreateMockDatabaseFactory(std::shared_ptr<Database> database, bool delayInCreate = false)
+{
+    std::shared_ptr<DatabaseFactory> mockDatabaseFactory(new MockDatabaseFactory);
+    EXPECT_CALL(*dynamic_cast<MockDatabaseFactory*>(mockDatabaseFactory.get()), CreateDatabase(_, _))
+        .WillRepeatedly(Invoke([database, delayInCreate](Unused, Unused)
+            {
+                if (delayInCreate)
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                return database;
+            }));
+    return mockDatabaseFactory;
+}

--- a/src/test/worlddump_test.cpp
+++ b/src/test/worlddump_test.cpp
@@ -145,15 +145,28 @@ GTEST_TEST_F(WorldDumpTest, RestoreFromDump_RestoresCharacters)
 
 GTEST_TEST_F(WorldDumpTest, DumpToFile_StoresGuilds)
 {
+}
 
+GTEST_TEST_F(WorldDumpTest, DumpToFile_ExistingGuild_Overwrites)
+{
+}
+
+GTEST_TEST_F(WorldDumpTest, RestoreFromDump_RestoresGuilds)
+{
 }
 
 GTEST_TEST_F(WorldDumpTest, DumpToFile_StoresMapItems)
 {
+}
 
+GTEST_TEST_F(WorldDumpTest, RestoreFromDump_RestoresMapItems)
+{
 }
 
 GTEST_TEST_F(WorldDumpTest, DumpToFile_StoresMapChests)
 {
+}
 
+GTEST_TEST_F(WorldDumpTest, RestoreFromDump_RestoresMapChests)
+{
 }

--- a/src/test/worlddump_test.cpp
+++ b/src/test/worlddump_test.cpp
@@ -15,7 +15,17 @@ class WorldDumpTest : public testing::Test
 {
 public:
     WorldDumpTest()
-        : dumpFileName("test_dump.bak.json") { }
+        : dumpFileName("test_dump.bak.json")
+    {
+        Console::SuppressOutput(true);
+
+        Config config, aConfig;
+        CreateConfigWithTestDefaults(config, aConfig);
+
+        database = CreateMockDatabase();
+        databaseFactory = CreateMockDatabaseFactory(database);
+        za_warudo = std::make_shared<World>(databaseFactory, config, aConfig);
+    }
 
     ~WorldDumpTest()
     {
@@ -29,44 +39,91 @@ public:
 
 protected:
     const std::string dumpFileName;
+
+    std::shared_ptr<Database> database;
+    std::shared_ptr<DatabaseFactory> databaseFactory;
+    std::shared_ptr<World> za_warudo;
+
+    std::list<Player> players;
+    std::list<Character> characters;
+
+    Player& CreatePlayer(const std::string name)
+    {
+        Player player(name);
+        player.world = za_warudo.get();
+        players.push_back(player);
+        return players.back();
+    }
+
+    Character& CreateCharacter(Player& player, const std::string name)
+    {
+        Character testChar(za_warudo.get());
+        testChar.player = &player;
+        testChar.real_name = name;
+
+        characters.push_back(testChar);
+        za_warudo->characters.push_back(&characters.back());
+
+        return characters.back();
+    }
+
+    nlohmann::json LoadDump()
+    {
+        nlohmann::json dump;
+        std::ifstream inFile(dumpFileName);
+        inFile >> dump;
+        inFile.close();
+        return dump;
+    }
 };
 
 GTEST_TEST_F(WorldDumpTest, DumpToFile_StoresCharacters)
 {
-    Console::SuppressOutput(true);
-
-    Config config, aConfig;
-    CreateConfigWithTestDefaults(config, aConfig);
-
-    auto database = CreateMockDatabase();
-    auto databaseFactory = CreateMockDatabaseFactory(database);
-    auto za_warudo = std::make_shared<World>(databaseFactory, config, aConfig);
-
     const std::string ExpectedName = "Dio Brando";
     const std::string ExpectedGuildRank = "Bisexual Vampire";
 
-    Player player(ExpectedName);
-    player.world = za_warudo.get();
+    auto& player = CreatePlayer(ExpectedName);
+    auto& character = CreateCharacter(player, ExpectedName);
+    character.guild_rank_string = ExpectedGuildRank;
 
-    Character testChar(za_warudo.get());
-    testChar.player = &player;
-
-    testChar.real_name = ExpectedName;
-    testChar.guild_rank_string = ExpectedGuildRank;
-
-    za_warudo->characters.push_back(&testChar);
     za_warudo->DumpToFile(dumpFileName);
 
-    nlohmann::json dump;
-    std::ifstream inFile(dumpFileName);
-    inFile >> dump;
-    inFile.close();
-
+    auto dump = LoadDump();
     ASSERT_NE(dump.find("characters"), dump.end());
     ASSERT_EQ(dump["characters"].size(), 1);
     ASSERT_EQ(dump["characters"].front()["account"], ExpectedName);
     ASSERT_EQ(dump["characters"].front()["name"], ExpectedName);
     ASSERT_EQ(dump["characters"].front()["guildrank_str"], ExpectedGuildRank);
+}
+
+GTEST_TEST_F(WorldDumpTest, DumpToFile_ExistingCharacter_Overwrites)
+{
+    const std::string ExistingName = "Jonathan Jostar";
+    const std::string ExistingGuildRank = "Gentleman";
+    const std::string ExistingTitle = "Hamon Master";
+    const std::string OverwriteGuildRank = "Star Platinum";
+
+    nlohmann::json dump;
+    dump["characters"] = nlohmann::json::array();
+    dump["characters"].push_back(nlohmann::json::object({{"name", ExistingName}, {"guildrank_str", ExistingGuildRank}, {"title", ExistingTitle}}));
+    std::ofstream existing(dumpFileName);
+    existing << dump;
+    existing.close();
+
+    auto& player = CreatePlayer(ExistingName);
+    auto& character = CreateCharacter(player, ExistingName);
+    character.guild_rank_string = OverwriteGuildRank;
+    character.title = ExistingTitle;
+
+    za_warudo->DumpToFile(dumpFileName);
+
+    dump = LoadDump();
+    ASSERT_NE(dump.find("characters"), dump.end());
+    ASSERT_EQ(dump["characters"].size(), 1);
+    ASSERT_EQ(dump["characters"].front()["account"], ExistingName);
+    ASSERT_EQ(dump["characters"].front()["name"], ExistingName);
+    ASSERT_EQ(dump["characters"].front()["guildrank_str"], OverwriteGuildRank);
+    ASSERT_EQ(dump["characters"].front()["title"], ExistingTitle);
 }
 
 GTEST_TEST_F(WorldDumpTest, RestoreFromDump_RestoresCharacters)

--- a/src/test/worlddump_test.cpp
+++ b/src/test/worlddump_test.cpp
@@ -258,7 +258,9 @@ protected:
         ASSERT_EQ((*character)["guildrank_str"], guild_rank_str);
 
         if (!title.empty())
+        {
             ASSERT_EQ((*character)["title"], title);
+        }
     }
 
     void AssertGuildProperties(const nlohmann::json& dump, const std::string& tag, const std::string& name)
@@ -640,7 +642,6 @@ GTEST_TEST_F(WorldDumpTest, RestoreFromDump_RestoresMapChests)
     {
         auto& expectedChestItem = chestPair.first;
         auto& expectedChest = chestPair.second->chests.front();
-        auto& expectedMap = chestPair.second;
 
         ASSERT_EQ(expectedChest->items.size(), 1);
 

--- a/src/test/worlddump_test.cpp
+++ b/src/test/worlddump_test.cpp
@@ -183,7 +183,7 @@ GTEST_TEST_F(WorldDumpTest, DumpToFile_StoresMapItems)
     std::list<std::pair<Map_Item*, Map*>> items;
     for (const auto& map : za_warudo->maps)
     {
-        items.push_back(std::make_pair(map->AddItem(1, 9999, 2, 2).get(), map));
+        items.push_back(std::make_pair(map->AddItem(rand() % 480, rand() % 10000, rand() % 25, rand() % 25).get(), map));
     }
     za_warudo->DumpToFile(dumpFileName);
 

--- a/src/test/worlddump_test.cpp
+++ b/src/test/worlddump_test.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+#include <json.hpp>
+#include <fstream>
+
+#include "world.hpp"
+#include "character.hpp"
+#include "player.hpp"
+
+#include "testhelper/mocks.hpp"
+#include "testhelper/setup.hpp"
+
+#include "console.hpp"
+
+class WorldDumpTest : public testing::Test
+{
+public:
+    WorldDumpTest()
+        : dumpFileName("test_dump.bak.json") { }
+
+    ~WorldDumpTest()
+    {
+        std::ifstream dumpFile(dumpFileName);
+        if (dumpFile.is_open())
+        {
+            dumpFile.close();
+            std::remove(dumpFileName.c_str());
+        }
+    }
+
+protected:
+    const std::string dumpFileName;
+};
+
+GTEST_TEST_F(WorldDumpTest, DumpToFile_StoresCharacters)
+{
+    Console::SuppressOutput(true);
+
+    Config config, aConfig;
+    CreateConfigWithTestDefaults(config, aConfig);
+
+    auto database = CreateMockDatabase();
+    auto databaseFactory = CreateMockDatabaseFactory(database);
+    auto za_warudo = std::make_shared<World>(databaseFactory, config, aConfig);
+
+    const std::string ExpectedName = "Dio Brando";
+    const std::string ExpectedGuildRank = "Bisexual Vampire";
+
+    Player player(ExpectedName);
+    player.world = za_warudo.get();
+
+    Character testChar(za_warudo.get());
+    testChar.player = &player;
+
+    testChar.real_name = ExpectedName;
+    testChar.guild_rank_string = ExpectedGuildRank;
+
+    za_warudo->characters.push_back(&testChar);
+    za_warudo->DumpToFile(dumpFileName);
+
+    nlohmann::json dump;
+    std::ifstream inFile(dumpFileName);
+    inFile >> dump;
+    inFile.close();
+
+    ASSERT_NE(dump.find("characters"), dump.end());
+    ASSERT_EQ(dump["characters"].size(), 1);
+    ASSERT_EQ(dump["characters"].front()["account"], ExpectedName);
+    ASSERT_EQ(dump["characters"].front()["name"], ExpectedName);
+    ASSERT_EQ(dump["characters"].front()["guildrank_str"], ExpectedGuildRank);
+}
+
+GTEST_TEST_F(WorldDumpTest, RestoreFromDump_RestoresCharacters)
+{
+}
+
+GTEST_TEST_F(WorldDumpTest, DumpToFile_StoresGuilds)
+{
+
+}
+
+GTEST_TEST_F(WorldDumpTest, DumpToFile_StoresMapItems)
+{
+
+}
+
+GTEST_TEST_F(WorldDumpTest, DumpToFile_StoresMapChests)
+{
+
+}

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -541,7 +541,7 @@ void World::DumpToFile(const std::string& fileName)
 	{
 		// right now merge means "overwrite file backup with live data if there are duplicates"
 		// eventually this could become more advanced but it probably isn't necessary
-		dump << existing;
+		existing >> dump;
 		existing.close();
 	}
 

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -556,7 +556,7 @@ void World::DumpToFile(const std::string& fileName)
 				return check.find("name") != check.end() && check["name"].get<std::string>() == c->real_name;
 			});
 		if (existing != dump["characters"].end())
-			dump.erase(existing);
+			dump["characters"].erase(existing);
 
 		auto nextC = nlohmann::json::object();
 
@@ -608,9 +608,8 @@ void World::DumpToFile(const std::string& fileName)
 	if (dump.find("mapState") == dump.end())
 		dump["mapState"] = nlohmann::json::object();
 
-	if (dump["mapState"].find("items") == dump["mapState"].end())
-		dump["mapState"]["items"] = nlohmann::json::array();
-
+	// overwrite all existing map item / chest spawns. prevents possibility of item dupes.
+	dump["mapState"]["items"] = nlohmann::json::array();
 	dump["mapState"]["chests"] = nlohmann::json::array();
 
 	auto& items = dump["mapState"]["items"];
@@ -620,14 +619,6 @@ void World::DumpToFile(const std::string& fileName)
 	{
 		UTIL_FOREACH_CREF(map->items, item)
 		{
-			auto existing = std::find_if(items.begin(), items.end(),
-				[&item](nlohmann::json check)
-				{
-					return check.find("uid") != check.end() && check["uid"].get<int>() == item->uid;
-				});
-			if (existing != items.end())
-				dump.erase(existing);
-
 			items.push_back(
 			{
 				{ "mapId", map->id },
@@ -672,7 +663,7 @@ void World::DumpToFile(const std::string& fileName)
 					return check.find("tag") != check.end() && check["tag"].get<std::string>() == guild->tag;
 				});
 			if (existing != dump["guilds"].end())
-				dump.erase(existing);
+				dump["guilds"].erase(existing);
 
 			dump["guilds"].push_back(
 			{

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -627,9 +627,7 @@ void World::DumpToFile(const std::string& fileName)
 				{ "y", item->y },
 				{ "itemId", item->id },
 				{ "amount", item->amount },
-				{ "uid", item->uid },
-				{ "owner", item->owner },
-				{ "unprotect", item->unprotecttime }
+				{ "uid", item->uid }
 			});
 		}
 

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -722,7 +722,7 @@ void World::RestoreFromDump(const std::string& fileName)
 			auto c = *c_iter;
 			auto charName = c["name"].get<std::string>();
 
-			auto exists = this->db->Query("SELECT COUNT(1) AS `count`, `usage` FROM `characters` WHERE `name` = '$'", charName.c_str());
+			auto exists = this->db->Query("SELECT `usage` FROM `characters` WHERE `name` = '$'", charName.c_str());
 			if (exists.Error())
 			{
 				Console::Wrn("Error checking existence of character %s during restore. Skipping restore.", charName.c_str());
@@ -730,7 +730,7 @@ void World::RestoreFromDump(const std::string& fileName)
 			}
 
 			Database_Result dbRes;
-			if (exists.empty() || exists.front()["count"].GetInt() != 1)
+			if (exists.empty())
 			{
 				dbRes = this->db->Query("INSERT INTO `characters` (`name`, `account`, `class`, `gender`, `race`, "
 					"`hairstyle`, `haircolor`, `map`, `x`, `y`, `direction`, `level`, `admin`, `exp`, `hp`, `tp`, `str`, `int`, `wis`, `agi`, `con`, `cha`, `statpoints`, `skillpoints`, `karma`, `sitting`, `hidden`, "

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -1816,9 +1816,4 @@ World::~World()
 	delete this->ecf;
 
 	delete this->guildmanager;
-
-	if (this->config["TimedSave"])
-	{
-		this->db->Commit();
-	}
 }

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -571,6 +571,7 @@ void World::DumpToFile(const std::string& fileName)
 		nextC["x"] = c->x;
 		nextC["y"] = c->y;
 		nextC["direction"] = c->direction;
+		nextC["admin"] = c->admin;
 		nextC["level"] = c->level;
 		nextC["exp"] = c->exp;
 		nextC["hp"] = c->hp;
@@ -717,13 +718,13 @@ void World::RestoreFromDump(const std::string& fileName)
 			if (exists.empty() || exists.front()["count"].GetInt() != 1)
 			{
 				dbRes = this->db->Query("INSERT INTO `characters` (`name`, `account`, `class`, `gender`, `race`, "
-					"`hairstyle`, `haircolor`, `map`, `x`, `y`, `direction`, `level`, `exp`, `hp`, `tp`, `str`, `int`, `wis`, `agi`, `con`, `cha`, `statpoints`, `skillpoints`, `karma`, `sitting`, `hidden`, "
+					"`hairstyle`, `haircolor`, `map`, `x`, `y`, `direction`, `level`, `admin`, `exp`, `hp`, `tp`, `str`, `int`, `wis`, `agi`, `con`, `cha`, `statpoints`, `skillpoints`, `karma`, `sitting`, `hidden`, "
 					"`nointeract`, `bankmax`, `goldbank`, `usage`, `inventory`, `bank`, `paperdoll`, `spells`, `guild`, `guild_rank`, `guild_rank_string`, `quest`) "
-					"VALUES ('$', '$', #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, '$', '$', '$', '$', '$', #, '$', '$')",
+					"VALUES ('$', '$', #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, '$', '$', '$', '$', '$', #, '$', '$')",
 					charName.c_str(), c["account"].get<std::string>().c_str(),
 					c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
 					c["hairstyle"].get<int>(), c["haircolor"].get<int>(), c["map"].get<int>(), c["x"].get<int>(), c["y"].get<int>(), c["direction"].get<int>(),
-					c["level"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
+					c["level"].get<int>(), c["admin"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
 					c["str"].get<int>(), c["intl"].get<int>(), c["wis"].get<int>(), c["agi"].get<int>(), c["con"].get<int>(), c["cha"].get<int>(),
 					c["statpoints"].get<int>(), c["skillpoints"].get<int>(), c["karma"].get<int>(), c["sitting"].get<int>(), c["hidden"].get<int>(),
 					c["nointeract"].get<int>(), c["bankmax"].get<int>(), c["goldbank"].get<int>(), c["usage"].get<int>(),
@@ -732,17 +733,17 @@ void World::RestoreFromDump(const std::string& fileName)
 					c["guildrank"].get<int>(), c["guildrank_str"].get<std::string>().c_str(), c["quest"].get<std::string>().c_str());
 			}
 			// if the database entry is older than the character data in the dump, update the database with the dump's character data
-			else if (exists.front()["usage"].GetInt() < c["usage"].get<int>())
+			else if (exists.front()["usage"].GetInt() <= c["usage"].get<int>())
 			{
 				dbRes = this->db->Query("UPDATE `characters` SET `class` = #, `gender` = #, `race` = #, "
-					"`hairstyle` = #, `haircolor` = #, `map` = #, `x` = #, `y` = #, `direction` = #, `level` = #, `exp` = #, `hp` = #, `tp` = #, "
+					"`hairstyle` = #, `haircolor` = #, `map` = #, `x` = #, `y` = #, `direction` = #, `level` = #, `admin` = #, `exp` = #, `hp` = #, `tp` = #, "
 					"`str` = #, `int` = #, `wis` = #, `agi` = #, `con` = #, `cha` = #, `statpoints` = #, `skillpoints` = #, `karma` = #, `sitting` = #, `hidden` = #, "
 					"`nointeract` = #, `bankmax` = #, `goldbank` = #, `usage` = #, `inventory` = '$', `bank` = '$', `paperdoll` = '$', "
 					"`spells` = '$', `guild` = '$', `guild_rank` = #, `guild_rank_string` = '$', `quest` = '$' "
 					"WHERE `name` = '$'",
 					c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
 					c["hairstyle"].get<int>(), c["haircolor"].get<int>(), c["map"].get<int>(), c["x"].get<int>(), c["y"].get<int>(), c["direction"].get<int>(),
-					c["level"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
+					c["level"].get<int>(), c["admin"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
 					c["str"].get<int>(), c["intl"].get<int>(), c["wis"].get<int>(), c["agi"].get<int>(), c["con"].get<int>(), c["cha"].get<int>(),
 					c["statpoints"].get<int>(), c["skillpoints"].get<int>(), c["karma"].get<int>(), c["sitting"].get<int>(), c["hidden"].get<int>(),
 					c["nointeract"].get<int>(), c["bankmax"].get<int>(), c["goldbank"].get<int>(), c["usage"].get<int>(),

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -784,19 +784,19 @@ void World::RestoreFromDump(const std::string& fileName)
 			Database_Result dbRes;
 			if (exists.empty() || exists.front()["count"].GetInt() != 1)
 			{
-				dbRes = this->db->Query("INSERT INTO `guilds` (`tag`, `name`, `description`, `ranks`, `bank`) VALUES ('$', '$', '$', '$', '$')",
+				dbRes = this->db->Query("INSERT INTO `guilds` (`tag`, `name`, `description`, `ranks`, `bank`) VALUES ('$', '$', '$', '$', #)",
 					guildTag.c_str(),
 					guildName.c_str(),
 					g["description"].get<std::string>().c_str(),
 					g["ranks"].get<std::string>().c_str(),
-					g["bank"].get<std::string>().c_str());
+					g["bank"].get<int>());
 			}
 			else
 			{
 				dbRes = this->db->Query("UPDATE `guilds` SET `description` = '$', `ranks` = '$', `bank` = # WHERE tag = '$'",
 					g["description"].get<std::string>().c_str(),
 					g["ranks"].get<std::string>().c_str(),
-					g["bank"].get<std::string>().c_str(),
+					g["bank"].get<int>(),
 					guildTag.c_str());
 			}
 

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -810,7 +810,7 @@ void World::RestoreFromDump(const std::string& fileName)
 
 			if (!dbRes.Error())
 			{
-				Console::Dbg("Restored guild: %s (%s)", guildName.c_str(), guildTag.c_str());
+				Console::Dbg("Restored guild:     %s (%s)", guildName.c_str(), guildTag.c_str());
 				restoredGuilds.push_back(g_iter);
 				// cache the guild that was just restored
 				(void)this->guildmanager->GetGuild(guildTag);
@@ -834,7 +834,7 @@ void World::RestoreFromDump(const std::string& fileName)
 
 	UTIL_FOREACH_CREF(dump["mapState"]["items"], i)
 	{
-		auto map = std::find_if(this->maps.begin(), this->maps.end(), [&i] (Map* m) { return m->id == i["mapId"]; });
+		auto map = std::find_if(this->maps.begin(), this->maps.end(), [&i] (Map* m) { return m->id == i["mapId"].get<int>(); });
 		if (map == this->maps.end())
 			continue;
 

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -727,8 +727,8 @@ void World::RestoreFromDump(const std::string& fileName)
 				dbRes = this->db->Query("INSERT INTO `characters` (`name`, `title`, `account`, `class`, `gender`, `race`, "
 					"`hairstyle`, `haircolor`, `map`, `x`, `y`, `direction`, `level`, `admin`, `exp`, `hp`, `tp`, `str`, `int`, `wis`, `agi`, `con`, `cha`, `statpoints`, `skillpoints`, `karma`, `sitting`, `hidden`, "
 					"`nointeract`, `bankmax`, `goldbank`, `usage`, `inventory`, `bank`, `paperdoll`, `spells`, `guild`, `guild_rank`, `guild_rank_string`, `quest`) "
-					"VALUES ('$', '$', #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, '$', '$', '$', '$', '$', #, '$', '$')",
-					charName.c_str(), c["title"].get<std::string>(), c["account"].get<std::string>().c_str(),
+					"VALUES ('$', '$', '$', #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, '$', '$', '$', '$', '$', #, '$', '$')",
+					charName.c_str(), c["title"].get<std::string>().c_str(), c["account"].get<std::string>().c_str(),
 					c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
 					c["hairstyle"].get<int>(), c["haircolor"].get<int>(), c["map"].get<int>(), c["x"].get<int>(), c["y"].get<int>(), c["direction"].get<int>(),
 					c["level"].get<int>(), c["admin"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
@@ -748,7 +748,7 @@ void World::RestoreFromDump(const std::string& fileName)
 					"`nointeract` = #, `bankmax` = #, `goldbank` = #, `usage` = #, `inventory` = '$', `bank` = '$', `paperdoll` = '$', "
 					"`spells` = '$', `guild` = '$', `guild_rank` = #, `guild_rank_string` = '$', `quest` = '$' "
 					"WHERE `name` = '$'",
-					c["title"].get<std::string>(), c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
+					c["title"].get<std::string>().c_str(), c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
 					c["hairstyle"].get<int>(), c["haircolor"].get<int>(), c["map"].get<int>(), c["x"].get<int>(), c["y"].get<int>(), c["direction"].get<int>(),
 					c["level"].get<int>(), c["admin"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
 					c["str"].get<int>(), c["intl"].get<int>(), c["wis"].get<int>(), c["agi"].get<int>(), c["con"].get<int>(), c["cha"].get<int>(),

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -562,6 +562,7 @@ void World::DumpToFile(const std::string& fileName)
 
 		nextC["name"] = c->real_name;
 		nextC["account"] = c->player->username;
+		nextC["title"] = c->title;
 		nextC["class"] = c->clas;
 		nextC["gender"] = c->gender;
 		nextC["race"] = c->race;
@@ -723,11 +724,11 @@ void World::RestoreFromDump(const std::string& fileName)
 			Database_Result dbRes;
 			if (exists.empty())
 			{
-				dbRes = this->db->Query("INSERT INTO `characters` (`name`, `account`, `class`, `gender`, `race`, "
+				dbRes = this->db->Query("INSERT INTO `characters` (`name`, `title`, `account`, `class`, `gender`, `race`, "
 					"`hairstyle`, `haircolor`, `map`, `x`, `y`, `direction`, `level`, `admin`, `exp`, `hp`, `tp`, `str`, `int`, `wis`, `agi`, `con`, `cha`, `statpoints`, `skillpoints`, `karma`, `sitting`, `hidden`, "
 					"`nointeract`, `bankmax`, `goldbank`, `usage`, `inventory`, `bank`, `paperdoll`, `spells`, `guild`, `guild_rank`, `guild_rank_string`, `quest`) "
 					"VALUES ('$', '$', #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, '$', '$', '$', '$', '$', #, '$', '$')",
-					charName.c_str(), c["account"].get<std::string>().c_str(),
+					charName.c_str(), c["title"].get<std::string>(), c["account"].get<std::string>().c_str(),
 					c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
 					c["hairstyle"].get<int>(), c["haircolor"].get<int>(), c["map"].get<int>(), c["x"].get<int>(), c["y"].get<int>(), c["direction"].get<int>(),
 					c["level"].get<int>(), c["admin"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
@@ -741,13 +742,13 @@ void World::RestoreFromDump(const std::string& fileName)
 			// if the database entry is older than the character data in the dump, update the database with the dump's character data
 			else if (exists.front()["usage"].GetInt() <= c["usage"].get<int>())
 			{
-				dbRes = this->db->Query("UPDATE `characters` SET `class` = #, `gender` = #, `race` = #, "
+				dbRes = this->db->Query("UPDATE `characters` SET `title` = $, `class` = #, `gender` = #, `race` = #, "
 					"`hairstyle` = #, `haircolor` = #, `map` = #, `x` = #, `y` = #, `direction` = #, `level` = #, `admin` = #, `exp` = #, `hp` = #, `tp` = #, "
 					"`str` = #, `int` = #, `wis` = #, `agi` = #, `con` = #, `cha` = #, `statpoints` = #, `skillpoints` = #, `karma` = #, `sitting` = #, `hidden` = #, "
 					"`nointeract` = #, `bankmax` = #, `goldbank` = #, `usage` = #, `inventory` = '$', `bank` = '$', `paperdoll` = '$', "
 					"`spells` = '$', `guild` = '$', `guild_rank` = #, `guild_rank_string` = '$', `quest` = '$' "
 					"WHERE `name` = '$'",
-					c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
+					c["title"].get<std::string>(), c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
 					c["hairstyle"].get<int>(), c["haircolor"].get<int>(), c["map"].get<int>(), c["x"].get<int>(), c["y"].get<int>(), c["direction"].get<int>(),
 					c["level"].get<int>(), c["admin"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
 					c["str"].get<int>(), c["intl"].get<int>(), c["wis"].get<int>(), c["agi"].get<int>(), c["con"].get<int>(), c["cha"].get<int>(),

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -45,6 +45,8 @@
 #include <utility>
 #include <vector>
 
+#include "json.hpp"
+
 void world_spawn_npcs(void *world_void)
 {
 	World *world(static_cast<World *>(world_void));
@@ -261,6 +263,8 @@ void world_timed_save(void *world_void)
 	if (!world->config["TimedSave"])
 		return;
 
+	world->db->BeginTransaction();
+
 	UTIL_FOREACH(world->characters, character)
 	{
 		character->Save();
@@ -270,7 +274,7 @@ void world_timed_save(void *world_void)
 
 	try
 	{
-		world->CommitDB();
+		world->db->Commit();
 	}
 	catch (Database_Exception& e)
 	{
@@ -278,8 +282,6 @@ void world_timed_save(void *world_void)
 		Console::Wrn("Database commit failed - no data was saved!");
 		world->db->Rollback();
 	}
-
-	world->BeginDB();
 }
 
 void world_spikes(void *world_void)
@@ -358,7 +360,7 @@ void World::UpdateConfig()
 	{
 		try
 		{
-			this->CommitDB();
+			this->db->Commit();
 		}
 		catch (Database_Exception& e)
 		{
@@ -377,8 +379,6 @@ World::World(std::shared_ptr<DatabaseFactory> databaseFactory, const Config &eos
 	, admin_count(0)
 {
 	this->db = databaseFactory->CreateDatabase(this->config, true);
-	this->BeginDB();
-
 	this->Initialize();
 }
 
@@ -532,16 +532,284 @@ void World::Initialize()
 	this->guildmanager = new GuildManager(this);
 }
 
-void World::BeginDB()
+void World::DumpToFile(const std::string& fileName)
 {
-	if (this->config["TimedSave"])
-		this->db->BeginTransaction();
+	// todo: merge if dump file already exists
+
+	nlohmann::json dump;
+
+	dump["characters"] = nlohmann::json::array();
+	UTIL_FOREACH_CREF(this->characters, c)
+	{
+		auto nextC = nlohmann::json::object();
+
+		nextC["name"] = c->real_name;
+		nextC["account"] = c->player->username;
+		nextC["class"] = c->clas;
+		nextC["gender"] = c->gender;
+		nextC["race"] = c->race;
+		nextC["hairstyle"] = c->hairstyle;
+		nextC["haircolor"] = c->haircolor;
+		nextC["map"] = c->mapid;
+		nextC["x"] = c->x;
+		nextC["y"] = c->y;
+		nextC["direction"] = c->direction;
+		nextC["level"] = c->level;
+		nextC["exp"] = c->exp;
+		nextC["hp"] = c->hp;
+		nextC["tp"] = c->tp;
+		nextC["str"] = c->str;
+		nextC["intl"] = c->intl;
+		nextC["wis"] = c->wis;
+		nextC["agi"] = c->agi;
+		nextC["con"] = c->con;
+		nextC["cha"] = c->cha;
+		nextC["statpoints"] = c->statpoints;
+		nextC["skillpoints"] = c->skillpoints;
+		nextC["karma"] = c->karma;
+		nextC["sitting"] = c->sitting;
+		nextC["hidden"] = c->hidden;
+		nextC["nointeract"] = c->nointeract;
+		nextC["bankmax"] = c->bankmax;
+		nextC["goldbank"] = c->goldbank;
+		nextC["usage"] = c->usage;
+		nextC["inventory"] = ItemSerialize(c->inventory);
+		nextC["bank"] = ItemSerialize(c->bank);
+		nextC["paperdoll"] = DollSerialize(c->paperdoll);
+		nextC["spells"] = SpellSerialize(c->spells);
+		nextC["guild"] = c->guild ? c->guild->tag : "";
+		nextC["guildrank"] = c->guild_rank;
+		nextC["guildrank_str"] = c->guild_rank_string;
+		nextC["quest"] = c->quest_string.empty()
+			? QuestSerialize(c->quests, c->quests_inactive)
+			: c->quest_string;
+
+		dump["characters"].push_back(nextC);
+	}
+
+	dump["mapState"] = nlohmann::json::object();
+
+	nlohmann::json items = nlohmann::json::array();
+	UTIL_FOREACH_CREF(this->maps, map)
+	{
+		UTIL_FOREACH_CREF(map->items, item)
+		{
+			items.push_back(
+			{
+				{ "mapId", map->id },
+				{ "x", item->x },
+				{ "y", item->y },
+				{ "itemId", item->id },
+				{ "amount", item->amount },
+				{ "uid", item->uid },
+				{ "owner", item->owner },
+				{ "unprotect", item->unprotecttime }
+			});
+		}
+	}
+	dump["mapState"]["items"] = items;
+
+	// todo: dump npcs/chests too
+	dump["mapState"]["chests"] = nlohmann::json::array();
+	dump["mapState"]["npcs"] = nlohmann::json::array();
+
+	dump["guilds"] = nlohmann::json::array();
+
+	UTIL_FOREACH_CREF(this->guildmanager->cache, guildPair)
+	{
+		std::shared_ptr<Guild> guild(guildPair.second);
+		if (guild)
+		{
+			dump["guilds"].push_back(
+			{
+				{ "tag", guild->tag },
+				{ "name", guild->name },
+				{ "description", guild->description },
+				{ "ranks", RankSerialize(guild->ranks) },
+				{ "bank", guild->bank }
+			});
+		}
+	}
+
+	std::ofstream file(fileName);
+	if (file.bad()) {
+		Console::Err("Error opening output file stream for world dump");
+		return;
+	}
+
+	file << dump.dump(2) << std::endl;
+	file.close();
 }
 
-void World::CommitDB()
+void World::RestoreFromDump(const std::string& fileName)
 {
-	if (this->db->Pending())
-		this->db->Commit();
+	std::ifstream file(fileName);
+	if (!file.is_open())
+	{
+		Console::Dbg("Unable to open input file stream for world restore.");
+		return;
+	}
+
+	nlohmann::json dump;
+	file >> dump;
+	file.close();
+
+	bool in_tran = this->db->BeginTransaction();
+	if (!in_tran)
+	{
+		Console::Wrn("Transaction open failed when restoring database");
+	}
+
+	try
+	{
+		std::list<nlohmann::json::iterator> restoredChars;
+		for (auto c_iter = dump["characters"].begin(); c_iter != dump["characters"].end(); ++c_iter)
+		{
+			auto c = *c_iter;
+			auto charName = c["name"].get<std::string>();
+
+			auto exists = this->db->Query("SELECT COUNT(1) AS `count` FROM `characters` WHERE `name` = '$'", charName.c_str());
+			if (exists.Error())
+			{
+				Console::Wrn("Error checking existence of character %s during restore. Skipping restore.", charName.c_str());
+				continue;
+			}
+
+			Database_Result dbRes;
+			if (exists.empty() || exists.front()["count"].GetInt() != 1)
+			{
+				dbRes = this->db->Query("INSERT INTO `characters` (`name`, `account`, `class`, `gender`, `race`, "
+					"`hairstyle`, `haircolor`, `map`, `x`, `y`, `direction`, `level`, `exp`, `hp`, `tp`, `str`, `int`, `wis`, `agi`, `con`, `cha`, `statpoints`, `skillpoints`, `karma`, `sitting`, `hidden`, "
+					"`nointeract`, `bankmax`, `goldbank`, `usage`, `inventory`, `bank`, `paperdoll`, `spells`, `guild`, `guild_rank`, `guild_rank_string`, `quest`) "
+					"VALUES ('$', '$', #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, #, '$', '$', '$', '$', '$', #, '$', '$')",
+					charName.c_str(), c["account"].get<std::string>().c_str(),
+					c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
+					c["hairstyle"].get<int>(), c["haircolor"].get<int>(), c["map"].get<int>(), c["x"].get<int>(), c["y"].get<int>(), c["direction"].get<int>(),
+					c["level"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
+					c["str"].get<int>(), c["intl"].get<int>(), c["wis"].get<int>(), c["agi"].get<int>(), c["con"].get<int>(), c["cha"].get<int>(),
+					c["statpoints"].get<int>(), c["skillpoints"].get<int>(), c["karma"].get<int>(), c["sitting"].get<int>(), c["hidden"].get<int>(),
+					c["nointeract"].get<int>(), c["bankmax"].get<int>(), c["goldbank"].get<int>(), c["usage"].get<int>(),
+					c["inventory"].get<std::string>().c_str(), c["bank"].get<std::string>().c_str(), c["paperdoll"].get<std::string>().c_str(),
+					c["spells"].get<std::string>().c_str(), c["guild"].get<std::string>().c_str(),
+					c["guildrank"].get<int>(), c["guildrank_str"].get<std::string>().c_str(), c["quest"].get<std::string>().c_str());
+			}
+			else
+			{
+				dbRes = this->db->Query("UPDATE `characters` SET `class` = #, `gender` = #, `race` = #, "
+					"`hairstyle` = #, `haircolor` = #, `map` = #, `x` = #, `y` = #, `direction` = #, `level` = #, `exp` = #, `hp` = #, `tp` = #, "
+					"`str` = #, `int` = #, `wis` = #, `agi` = #, `con` = #, `cha` = #, `statpoints` = #, `skillpoints` = #, `karma` = #, `sitting` = #, `hidden` = #, "
+					"`nointeract` = #, `bankmax` = #, `goldbank` = #, `usage` = #, `inventory` = '$', `bank` = '$', `paperdoll` = '$', "
+					"`spells` = '$', `guild` = '$', `guild_rank` = #, `guild_rank_string` = '$', `quest` = '$' "
+					"WHERE `name` = '$'",
+					c["class"].get<int>(), c["gender"].get<int>(), c["race"].get<int>(),
+					c["hairstyle"].get<int>(), c["haircolor"].get<int>(), c["map"].get<int>(), c["x"].get<int>(), c["y"].get<int>(), c["direction"].get<int>(),
+					c["level"].get<int>(), c["exp"].get<int>(), c["hp"].get<int>(), c["tp"].get<int>(),
+					c["str"].get<int>(), c["intl"].get<int>(), c["wis"].get<int>(), c["agi"].get<int>(), c["con"].get<int>(), c["cha"].get<int>(),
+					c["statpoints"].get<int>(), c["skillpoints"].get<int>(), c["karma"].get<int>(), c["sitting"].get<int>(), c["hidden"].get<int>(),
+					c["nointeract"].get<int>(), c["bankmax"].get<int>(), c["goldbank"].get<int>(), c["usage"].get<int>(),
+					c["inventory"].get<std::string>().c_str(), c["bank"].get<std::string>().c_str(), c["paperdoll"].get<std::string>().c_str(),
+					c["spells"].get<std::string>().c_str(), c["guild"].get<std::string>().c_str(),
+					c["guildrank"].get<int>(), c["guildrank_str"].get<std::string>().c_str(), c["quest"].get<std::string>().c_str(),
+					charName.c_str());
+			}
+
+			if (!dbRes.Error())
+			{
+				Console::Dbg("Restored character: %s", charName.c_str());
+				restoredChars.push_back(c_iter);
+			}
+		}
+
+		std::list<nlohmann::json::iterator> restoredGuilds;
+		for (auto g_iter = dump["guilds"].begin(); g_iter != dump["guilds"].end(); ++g_iter)
+		{
+			auto g = *g_iter;
+			auto guildTag = g["tag"].get<std::string>();
+			auto guildName = g["name"].get<std::string>();
+
+			auto exists = this->db->Query("SELECT COUNT(1) AS `count` FROM `guilds` WHERE `tag` = '$'", guildTag.c_str());
+			if (exists.Error())
+			{
+				Console::Wrn("Error checking existence of guild %s during restore. Skipping restore.", guildTag.c_str());
+				continue;
+			}
+
+			Database_Result dbRes;
+			if (exists.empty() || exists.front()["count"].GetInt() != 1)
+			{
+				dbRes = this->db->Query("INSERT INTO `guilds` (`tag`, `name`, `description`, `ranks`, `bank`) VALUES ('$', '$', '$', '$', '$')",
+					guildTag.c_str(),
+					guildName.c_str(),
+					g["description"].get<std::string>().c_str(),
+					g["ranks"].get<std::string>().c_str(),
+					g["bank"].get<std::string>().c_str());
+			}
+			else
+			{
+				dbRes = this->db->Query("UPDATE `guilds` SET `description` = '$', `ranks` = '$', `bank` = # WHERE tag = '$'",
+					g["description"].get<std::string>().c_str(),
+					g["ranks"].get<std::string>().c_str(),
+					g["bank"].get<std::string>().c_str(),
+					guildTag.c_str());
+			}
+
+			if (!dbRes.Error())
+			{
+				Console::Dbg("Restored guild: %s (%s)", guildName.c_str(), guildTag.c_str());
+				restoredGuilds.push_back(g_iter);
+				// cache the guild that was just restored
+				(void)this->guildmanager->GetGuild(guildTag);
+			}
+		}
+
+		if (in_tran)
+			this->db->Commit();
+
+		UTIL_FOREACH(restoredChars, c)
+			dump["characters"].erase(c);
+
+		UTIL_FOREACH(restoredGuilds, g)
+			dump["guilds"].erase(g);
+	}
+	catch (Database_Exception& dbe)
+	{
+		Console::Err("Database operation failed during restore. %s: %s", dbe.what(), dbe.error());
+		this->db->Rollback();
+	}
+
+	UTIL_FOREACH_CREF(dump["mapState"]["items"], i)
+	{
+		auto map = std::find_if(this->maps.begin(), this->maps.end(), [&i] (Map* m) { return m->id == i["mapId"]; });
+		if (map == this->maps.end())
+			continue;
+
+		(*map)->items.push_back(
+			std::make_shared<Map_Item>(
+				i["uid"].get<short>(),
+				i["itemId"].get<short>(),
+				i["amount"].get<int>(),
+				i["x"].get<unsigned char>(),
+				i["y"].get<unsigned char>(),
+				0, 0));
+
+		Console::Dbg("Restored item:     %dx%d", i["itemId"].get<short>(), i["amount"].get<short>());
+	}
+
+	if (dump["characters"].empty() && dump["guilds"].empty())
+	{
+		std::remove(fileName.c_str());
+	}
+	else
+	{
+		std::ofstream rewrite(fileName);
+		if (!rewrite.is_open())
+		{
+			throw std::runtime_error("Unable to update the world dump file after partially restoring world state");
+		}
+
+		rewrite << dump.dump(2) << std::endl;
+		rewrite.close();
+	}
 }
 
 void World::UpdateAdminCount(int admin_count)

--- a/src/world.hpp
+++ b/src/world.hpp
@@ -130,8 +130,8 @@ class World
 
 		void Initialize();
 
-		void BeginDB();
-		void CommitDB();
+		void DumpToFile(const std::string& fileName);
+		void RestoreFromDump(const std::string& fileName);
 
 		void UpdateAdminCount(int admin_count);
 		void IncAdminCount() { UpdateAdminCount(this->admin_count + 1); }


### PR DESCRIPTION
Add support for dumping and restoring the world object when server shuts down and starts. Both graceful and ungraceful shutdown cases will capture a crash dump in the configured file location. This file is formatted as json. A new dependency is added to `nlohmann::json` (installed via the `install-dependencies` script for a given platform).

Crash dump occurs when server throws an exception or traps a fatal signal. It also happens unconditionally on graceful shutdown of the server. When launching, the dump file is examined if it exists and state is restored. Characters, guilds, map items, and chest items are captured for restoration. NPC state is not captured since this is much more dynamic.

Characters will not be restored if an existing character in the database has a higher `usage` property. Any other existing state is clobbered by what is contained in the crash dump file, as world restoration should only ever be called when the server is first starting up.

A side effect of this change is the removal of the long-running transaction that is constantly open. TimedSave will now write state to the database instead of committing a transaction and opening a new one. This fixes issues with using sqlite after background thread changes were added to login and account creation, since multiple threads were trying to perform operations on the database concurrently (which is a big no-no in the world of sqlite).