### PR TITLE
Add dockerfile and docker build/push to azure pipelines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,12 @@
 # See LICENSE.txt for more info.
 
 cmake_minimum_required(VERSION 2.6)
-project(eoserv C CXX)
+cmake_policy(SET CMP0048 NEW)
+cmake_policy(SET CMP0054 NEW)
+
+project(etheos VERSION 0.7.1 LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-
-cmake_policy(SET CMP0054 NEW)
 
 # ---------
 #  Options
@@ -177,7 +178,7 @@ include(DownloadGoogleTest)
 # ---------
 
 add_library(eoserv_lib STATIC ${eoserv_SOURCE_FILES})
-add_executable(eoserv ${eoserv_MAIN_FILES})
+add_executable(etheos ${eoserv_MAIN_FILES})
 add_executable(eoserv_test ${TestFiles})
 
 target_include_directories(eoserv_test PUBLIC ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/json)
@@ -239,16 +240,16 @@ endif()
 
 include(DownloadBcrypt)
 
-target_include_directories(eoserv PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
+target_include_directories(etheos PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
 target_include_directories(eoserv_lib PUBLIC ${CMAKE_BINARY_DIR}/bcrypt-src/include)
 list(APPEND eoserv_LIBRARIES bcrypt)
 
 target_include_directories(eoserv_lib PUBLIC ${CMAKE_SOURCE_DIR}/json)
 
-target_link_libraries(eoserv eoserv_lib)
+target_link_libraries(etheos eoserv_lib)
 target_link_libraries(eoserv_lib ${eoserv_LIBRARIES})
 
-install(TARGETS eoserv RUNTIME DESTINATION .)
+install(TARGETS etheos RUNTIME DESTINATION .)
 install(TARGETS eoserv_test RUNTIME DESTINATION ./test)
 
 foreach (File ${ExtraFiles})
@@ -293,7 +294,7 @@ if(EOSERV_USE_PRECOMPILED_HEADERS)
 	compile_pch(eoserv-pch ${CMAKE_BINARY_DIR}/eoserv-pch.h)
 
 	add_dependencies(eoserv-pch-autogen eoserv-pch)
-	add_dependencies(eoserv eoserv-pch)
+	add_dependencies(etheos eoserv-pch)
 	add_dependencies(eoserv_lib eoserv-pch)
 
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${eoserv-pch_INCLUDE_FLAG}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:20.04
+
+COPY scripts/install-deps.sh /tmp
+RUN mkdir /eoserv
+COPY install/*.sql /eoserv
+COPY install/*.ini /eoserv
+COPY install/LICENSE.txt /eoserv
+COPY install/eoserv /eoserv/eoserv
+
+COPY install/upgrade/ /eoserv/upgrade
+COPY install/lang/ /eoserv/lang
+COPY install/config/ /eoserv/config
+WORKDIR /eoserv
+
+RUN apt-get update && apt-get install -y curl gnupg2 &&\
+    /tmp/install-deps.sh --skip-cmake --skip-json &&\
+    apt-get clean && rm /tmp/install-deps.sh
+EXPOSE 8078
+
+CMD [ "./eoserv" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,14 @@
 FROM ubuntu:20.04
 
 COPY scripts/install-deps.sh /tmp
-RUN mkdir /eoserv
-COPY install/*.sql /eoserv
-COPY install/*.ini /eoserv
-COPY install/LICENSE.txt /eoserv
-COPY install/eoserv /eoserv/eoserv
-
-COPY install/upgrade/ /eoserv/upgrade
-COPY install/lang/ /eoserv/lang
-COPY install/config/ /eoserv/config
-WORKDIR /eoserv
+RUN mkdir /etheos
+COPY install/ /etheos
+RUN rm -rf /etheos/config /etheos/config_local /etheos/test
+WORKDIR /etheos
 
 RUN apt-get update && apt-get install -y curl gnupg2 &&\
     /tmp/install-deps.sh --skip-cmake --skip-json &&\
     apt-get clean && rm /tmp/install-deps.sh
 EXPOSE 8078
 
-CMD [ "./eoserv" ]
+CMD [ "./etheos" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 COPY scripts/install-deps.sh /tmp
 RUN mkdir /etheos
 COPY install/ /etheos
-RUN rm -rf /etheos/config /etheos/config_local /etheos/test
+RUN rm -rf /etheos/config_local /etheos/test
 WORKDIR /etheos
 
 RUN apt-get update && apt-get install -y curl gnupg2 &&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,23 +86,23 @@ stages:
         command: login
         containerRegistry: etheos
     - task: Docker@2
-      condition: not(eq(variables['Build.Reason'], 'IndividualCI'))
+      condition: not(or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Schedule')))
       displayName: 'Build/push etheos image'
       inputs:
         command: buildAndPush
         repository: etheos/dev
         tags: |
           $(Build.BuildNumber)
-          $(Build.SourceBranchName)
+          latest
     - task: Docker@2
-      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      condition: or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Schedule'))
       displayName: 'Push etheos:test image - CI build'
       inputs:
         command: push
         repository: etheos/test
         tags: |
           $(Build.BuildNumber)
-          $(Build.SourceBranchName)
+          latest
 
   - job: tag_sources
     displayName: 'Tag on success'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ stages:
           dev/$(Build.BuildNumber)
           dev/$(Build.SourceBranchName)
     - task: Docker@2
-      condition: eq(variabls['Build.Reason'], 'IndividualCI')
+      condition: eq(variables['Build.Reason'], 'IndividualCI')
       displayName: 'Push etheos:test image - CI build'
       inputs:
         command: push

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ stages:
 - stage: build_test
   displayName: 'Build + Test'
   jobs:
-  - job:
+  - job: build_linux
     displayName: 'Build - Release - Ubuntu (MariaDB + SQL Server + Sqlite)'
     pool:
       vmImage: 'ubuntu-latest'
@@ -38,7 +38,7 @@ stages:
         ArtifactName: 'linux'
         publishLocation: 'Container'
 
-  - job:
+  - job: build_windows
     displayName: 'Build - Release - Windows (MariaDB + SQL Server + Sqlite)'
     pool:
       vmImage: 'windows-latest'
@@ -63,3 +63,30 @@ stages:
         PathtoPublish: 'install'
         ArtifactName: 'windows'
         publishLocation: 'Container'
+
+  - job:
+    displayName: 'Docker build'
+    dependsOn: build_linux
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+      lfs: true
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        downloadType: 'single'
+        artifactName: 'linux'
+        downloadPath: '$(Build.SourcesDirectory)'
+    - script: mv linux install
+      displayName: 'Rename linux dir -> install'
+    - task: Docker@2
+      inputs:
+        command: login
+        containerRegistry: etheos
+    - task: Docker@2
+      inputs:
+        command: buildAndPush
+        repository: etheos
+        tags: |
+          $(Build.BuildNumber)
+          $(Build.SourceBranchName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,14 +79,26 @@ stages:
         downloadPath: '$(Build.SourcesDirectory)'
     - script: mv linux install
       displayName: 'Rename linux dir -> install'
+    - script: chmod +x install/etheos
+      displayName: 'Make etheos binary executable'
     - task: Docker@2
       inputs:
         command: login
         containerRegistry: etheos
     - task: Docker@2
+      displayName: 'Build/push etheos image'
       inputs:
         command: buildAndPush
         repository: etheos
         tags: |
-          $(Build.BuildNumber)
-          $(Build.SourceBranchName)
+          dev/$(Build.BuildNumber)
+          dev/$(Build.SourceBranchName)
+    - task: Docker@2
+      condition: eq(variabls['Build.Reason'], 'IndividualCI')
+      displayName: 'Push etheos:test image - CI build'
+      inputs:
+        command: push
+        repository: etheos
+        tags: |
+          test/$(Build.BuildNumber)
+          test/$(Build.SourceBranchName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,19 +89,19 @@ stages:
       displayName: 'Build/push etheos image'
       inputs:
         command: buildAndPush
-        repository: etheos
+        repository: etheos/dev
         tags: |
-          dev/$(Build.BuildNumber)
-          dev/$(Build.SourceBranchName)
+          $(Build.BuildNumber)
+          $(Build.SourceBranchName)
     - task: Docker@2
       condition: eq(variables['Build.Reason'], 'IndividualCI')
       displayName: 'Push etheos:test image - CI build'
       inputs:
         command: push
-        repository: etheos
+        repository: etheos/test
         tags: |
-          test/$(Build.BuildNumber)
-          test/$(Build.SourceBranchName)
+          $(Build.BuildNumber)
+          $(Build.SourceBranchName)
 
   - job: tag_sources
     displayName: 'Tag on success'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ stages:
         ArtifactName: 'windows'
         publishLocation: 'Container'
 
-  - job:
+  - job: build_docker
     displayName: 'Docker build'
     dependsOn: build_linux
     pool:
@@ -102,3 +102,18 @@ stages:
         tags: |
           test/$(Build.BuildNumber)
           test/$(Build.SourceBranchName)
+
+  - job: tag_sources
+    displayName: 'Tag on success'
+    dependsOn: [ 'build_windows', 'build_linux', 'build_docker' ]
+    condition: succeeded()
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: self
+      lfs: true
+      persistCredentials: true
+    - script: |
+        git tag build/$(Build.BuildNumber)
+        git push origin build/$(Build.BuildNumber)
+      workingDirectory: $(Build.SourcesDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,6 +86,7 @@ stages:
         command: login
         containerRegistry: etheos
     - task: Docker@2
+      condition: not(eq(variables['Build.Reason'], 'IndividualCI'))
       displayName: 'Build/push etheos image'
       inputs:
         command: buildAndPush

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -6,6 +6,7 @@ SKIPCMAKE=false
 SKIPMARIADB=false
 SKIPSQLITE=false
 SKIPSQLSERVER=false
+SKIPJSON=false
 HELP=false
 
 function parse_options {
@@ -17,6 +18,7 @@ function parse_options {
       --skip-mariadb)         SKIPMARIADB=true        ;;
       --skip-sqlite)          SKIPSQLITE=true         ;;
       --skip-odbc)            SKIPSQLSERVER=true      ;;
+      --skip-json)            SKIPJSON=true           ;;
       *)                      HELP=true               ; break ;;
     esac
     shift
@@ -31,6 +33,7 @@ if [ "$HELP" == "true" ]; then
     echo "  --skip-mariadb           Skip MariaDB download"
     echo "  --skip-sqlite            Skip SQLite download"
     echo "  --skip-odbc              Skip ODBC (SQL Server) download"
+    echo "  --skip-json              Skip JSON library download"
     echo -e "\nThis script must be run as sudo."
 
     exit 0
@@ -116,10 +119,10 @@ echo "Installing packages: $PACKAGES"
 
 if [ "$PLATFORM_NAME" == "ubuntu" ]; then
     apt-get update > /dev/null
-    sudo ACCEPT_EULA=Y apt-get install -y $PACKAGES
+    ACCEPT_EULA=Y apt-get install -y $PACKAGES
 elif [ "$PLATFORM_NAME" == "rhel" ]; then
     yum makecache fast > /dev/null
-    sudo ACCEPT_EULA=Y yum install -y $PACKAGES
+    ACCEPT_EULA=Y yum install -y $PACKAGES
 fi
 
 if [ "$SKIPCMAKE" == "false" ]; then
@@ -135,11 +138,13 @@ if [ "$SKIPCMAKE" == "false" ]; then
     rm cmake-3.16.0-Linux-x86_64.sh
 fi
 
-echo "Installing json library dependency"
+if [ "$SKIPJSON" == "false" ]; then
+    echo "Installing json library dependency"
 
-if [ ! -d ../json ]; then
-    mkdir ../json
+    if [ ! -d ../json ]; then
+        mkdir ../json
+    fi
+    JSON_VERSION=3.9.1
+    wget -q "https://raw.githubusercontent.com/nlohmann/json/v$JSON_VERSION/single_include/nlohmann/json.hpp"
+    mv json.hpp ../json
 fi
-JSON_VERSION=3.9.1
-wget -q "https://raw.githubusercontent.com/nlohmann/json/v$JSON_VERSION/single_include/nlohmann/json.hpp"
-mv json.hpp ../json

--- a/src/eoserv_config.cpp
+++ b/src/eoserv_config.cpp
@@ -10,11 +10,30 @@
 
 #include "console.hpp"
 
+#include <algorithm>
+#include <cstdlib>
 #include <string>
 
-template <typename T> static void eoserv_config_default(Config& config, const char* key, T value)
+static std::string eoserv_config_fromenv(const char* key)
 {
-	if (config.find(key) == config.end())
+	std::string envKey("etheos_");
+	envKey += key;
+	std::transform(envKey.begin(), envKey.end(), envKey.begin(), ::toupper);
+
+	auto envVal = getenv(envKey.c_str());
+	return std::string(envVal ? envVal : "");
+}
+
+template <typename T>
+static void eoserv_config_default(Config& config, const char* key, T value)
+{
+	std::string envVal = eoserv_config_fromenv(key);
+	if (envVal.length() != 0)
+	{
+		config[key] = util::variant(envVal);
+		Console::Wrn("Overriding config value '%s' with value from environment variable (%s)", key, config[key].GetString().c_str());
+	}
+	else if (config.find(key) == config.end())
 	{
 		config[key] = util::variant(value);
 		Console::Wrn("Could not load config value '%s' - using default (%s)", key, std::string(config[key]).c_str());

--- a/src/eoserv_windows.h
+++ b/src/eoserv_windows.h
@@ -35,4 +35,6 @@
 #undef max
 #endif
 
+#define setenv(_Name, _Value, _Overwrite) _putenv_s(_Name, _Value)
+
 #endif // EOSERV_WINDOWS_H_INCLUDED

--- a/src/test/config_test.cpp
+++ b/src/test/config_test.cpp
@@ -1,12 +1,17 @@
 #include <gtest/gtest.h>
+
 #include "config.hpp"
 #include "console.hpp"
 #include "eoserv_config.hpp"
 
+#ifdef _WIN32
+#include "eoserv_windows.h"
+#endif
+
 GTEST_TEST(ConfigTests, EoservConfig_ValueFromEnvironmentVariable_OverridesFileValue)
 {
     Console::SuppressOutput(true);
-    ::setenv("ETHEOS_PORT", "12345", 1);
+    setenv("ETHEOS_PORT", "12345", 1);
 
     Config config;
     eoserv_config_validate_config(config);

--- a/src/test/config_test.cpp
+++ b/src/test/config_test.cpp
@@ -1,16 +1,15 @@
 #include <gtest/gtest.h>
 #include "config.hpp"
+#include "console.hpp"
+#include "eoserv_config.hpp"
 
-GTEST_TEST(ConfigTests, SampleTestPasses)
+GTEST_TEST(ConfigTests, EoservConfig_ValueFromEnvironmentVariable_OverridesFileValue)
 {
-    Config config;
-    ASSERT_TRUE(true);
-}
-
-GTEST_TEST(ConfigTests, SampleTestFails)
-{
-    GTEST_SKIP();
+    Console::SuppressOutput(true);
+    ::setenv("ETHEOS_PORT", "12345", 1);
 
     Config config;
-    ASSERT_TRUE(false);
+    eoserv_config_validate_config(config);
+
+    ASSERT_EQ(config["Port"].GetInt(), 12345);
 }

--- a/src/test/testhelper/setup.hpp
+++ b/src/test/testhelper/setup.hpp
@@ -18,6 +18,14 @@ static void CreateConfigWithTestDefaults(Config& config, Config& admin_config)
     config["ESF"] = "../data/pub/empty.esf";
     config["ECF"] = "../data/pub/empty.ecf";
 
+    config["DropsFile"] = "../data/drops.ini";
+    config["ShopsFile"] = "../data/shops.ini";
+    config["ArenasFile"] = "../data/arenas.ini";
+    config["FormulasFile"] = "../data/formulas.ini";
+    config["HomeFile"] = "../data/home.ini";
+    config["SkillsFile"] = "../data/skills.ini";
+    config["SpeechFile"] = "../data/speech.ini";
+
     //turn off SLN
     config["SLN"] = "false";
     // turn off timed save

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
 
 // Expected to be exactly 5 characters long
 #ifndef EOSERV_VERSION_STRING
-#define EOSERV_VERSION_STRING "0.7.0"
+#define EOSERV_VERSION_STRING "0.7.1"
 #endif // EOSERV_VERSION_STRING
 
 #endif // VERSION_H_INCLUDED


### PR DESCRIPTION
Build pipeline will automatically push and tag a docker image with the build version number. Non-CI builds will tag dev/branchname, CI builds will tag test/branchname (for eventual deployment to kubernetes)

Includes these additional changes:
- Update version to 0.7.1 everywhere
- Use 'etheos' instead of 'eoserv'
- Allow for overriding config values from environment variables, in format of ETHEOS_{configkey} (uppercase)