### PR TITLE
Change gtest branch from master to main

### DIFF
--- a/cmake/gtestproj.cmake
+++ b/cmake/gtestproj.cmake
@@ -6,7 +6,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
The GoogleTest repo has changed its default branch from master to main.