### PR TITLE
Load config values from environment on config read instead of on setting default config

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -21,12 +21,17 @@
  */
 class Config : public std::unordered_map<std::string, util::variant>
 {
+	private:
+		void LoadFromEnvironment(const std::string& key);
+
 	protected:
 		/**
 		 * Filename of the configuration file.
 		 * Stored in case save support is ever added.
 		 */
 		std::string filename;
+
+		std::list<std::string> loadedEnvs;
 
 	public:
 		/**
@@ -50,6 +55,9 @@ class Config : public std::unordered_map<std::string, util::variant>
 		 * @param filename File to read from.
 		 */
 		void Read(const std::string& filename);
+
+		util::variant& operator[](const std::string& key);
+		util::variant& operator[](std::string&& key);
 };
 
 #endif // CONFIG_HPP_INCLUDED

--- a/src/eoserv_config.cpp
+++ b/src/eoserv_config.cpp
@@ -14,26 +14,11 @@
 #include <cstdlib>
 #include <string>
 
-static std::string eoserv_config_fromenv(const char* key)
-{
-	std::string envKey("etheos_");
-	envKey += key;
-	std::transform(envKey.begin(), envKey.end(), envKey.begin(), ::toupper);
-
-	auto envVal = getenv(envKey.c_str());
-	return std::string(envVal ? envVal : "");
-}
 
 template <typename T>
 static void eoserv_config_default(Config& config, const char* key, T value)
 {
-	std::string envVal = eoserv_config_fromenv(key);
-	if (envVal.length() != 0)
-	{
-		config[key] = util::variant(envVal);
-		Console::Wrn("Overriding config value '%s' with value from environment variable (%s)", key, config[key].GetString().c_str());
-	}
-	else if (config.find(key) == config.end())
+	if (config.find(key) == config.end())
 	{
 		config[key] = util::variant(value);
 		Console::Wrn("Could not load config value '%s' - using default (%s)", key, std::string(config[key]).c_str());

--- a/src/test/config_test.cpp
+++ b/src/test/config_test.cpp
@@ -14,7 +14,7 @@ GTEST_TEST(ConfigTests, EoservConfig_ValueFromEnvironmentVariable_OverridesFileV
     setenv("ETHEOS_PORT", "12345", 1);
 
     Config config;
-    eoserv_config_validate_config(config);
+    (void)config["Port"];
 
     ASSERT_EQ(config["Port"].GetInt(), 12345);
 }


### PR DESCRIPTION
Allows for any key to be loaded from environment, not just keys that have a default in eoserv_config.cpp