### PR TITLE
Add deployment to CI test environment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,11 +98,11 @@ stages:
           $(Build.BuildNumber)
           latest
     - task: Docker@2
-      condition: or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'Schedule'))
-      displayName: 'Push etheos:test image - CI build'
+      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      displayName: 'Push etheos:ci-test image - CI build'
       inputs:
         command: buildAndPush
-        repository: etheos/test
+        repository: etheos/ci-test
         tags: |
           $(Build.BuildNumber)
           latest
@@ -130,9 +130,41 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
     - checkout: self
+      lfs: true
     - script: $(Build.SourcesDirectory)/deploy/deploy.sh -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e dev
       condition: not(eq(variables['Build.Reason'], 'IndividualCI'))
-    # TODO: deploy to ci-test environment on CI builds
-    #       separate pipeline for ci tests; if that is successful, deploy to test
-    - script: $(Build.SourcesDirectory)/deploy/deploy.sh -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e ci-test
+      displayName: 'PR/Manual Builds - Deploy to dev environment'
+    - script: $(Build.SourcesDirectory)/deploy/deploy.sh -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e ci-test -g etheos --template-file $(Build.SourcesDirectory)/deploy/etheos-ci-test.json --parameter-file $(Build.SourcesDirectory)/deploy/params-ci-test.json
       condition: eq(variables['Build.Reason'], 'IndividualCI')
+      displayName: 'CI Builds - Deploy to ci-test environment'
+    # TODO: run CI tests, only build/deploy test image on success
+    #
+    - task: DownloadBuildArtifacts@0
+      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      inputs:
+        downloadType: 'single'
+        artifactName: 'linux'
+        downloadPath: '$(Build.SourcesDirectory)'
+    - script: mv linux install
+      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      displayName: 'Rename linux dir -> install'
+    - script: chmod +x install/etheos
+      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      displayName: 'Make etheos binary executable'
+    - task: Docker@2
+      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      inputs:
+        command: login
+        containerRegistry: etheos
+    - task: Docker@2
+      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      displayName: 'Push etheos:test image - CI build'
+      inputs:
+        command: buildAndPush
+        repository: etheos/test
+        tags: |
+          $(Build.BuildNumber)
+          latest
+    - script: $(Build.SourcesDirectory)/deploy/deploy.sh -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e test
+      condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'))
+      displayName: 'Successful CI Builds - Deploy to test environment'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,5 +134,5 @@ stages:
       condition: not(eq(variables['Build.Reason'], 'IndividualCI'))
     # TODO: deploy to ci-test environment on CI builds
     #       separate pipeline for ci tests; if that is successful, deploy to test
-    - script: $(Build.SourcesDirectory)/deploy/deploy.sh -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e test
+    - script: $(Build.SourcesDirectory)/deploy/deploy.sh -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e ci-test
       condition: eq(variables['Build.Reason'], 'IndividualCI')

--- a/deploy/etheos-ci-test.json
+++ b/deploy/etheos-ci-test.json
@@ -1,0 +1,402 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "sqlDbPass": {
+      "type": "securestring"
+    },
+    "imageRegistryPass": {
+      "type": "securestring"
+    },
+    "storageAccountName": {
+      "type": "string"
+    },
+    "storageAccountKey": {
+      "type": "securestring"
+    }
+  },
+  "variables": {
+    "dbContainerName": "etheos-ci-test-db",
+    "containerName": "etheos-ci-test"
+  },
+  "resources": [
+    {
+      "name": "[variables('dbContainerName')]",
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2021-07-01",
+      "location": "westus",
+      "properties":
+      {
+        "containers": [
+          {
+            "name": "mssql-db",
+            "properties": {
+              "image": "mcr.microsoft.com/mssql/server:2019-latest",
+              "resources": {
+                "requests": {
+                  "cpu": 0.5,
+                  "memoryInGB": 1.5
+                }
+              },
+              "ports": [
+                {
+                  "port": 1433
+                }
+              ],
+              "environmentVariables": [
+                {
+                  "name": "SA_PASSWORD",
+                  "secureValue": "[parameters('sqlDbPass')]"
+                },
+                {
+                  "name": "ACCEPT_EULA",
+                  "value": "Y"
+                }
+              ]
+            }
+          },
+          {
+            "name": "mysql-db",
+            "properties": {
+              "image": "mariadb",
+              "resources": {
+                "requests": {
+                  "cpu": 0.5,
+                  "memoryInGB": 0.5
+                }
+              },
+              "ports": [
+                {
+                  "port": 3306
+                }
+              ],
+              "environmentVariables": [
+                {
+                  "name": "MYSQL_ROOT_PASSWORD",
+                  "secureValue": "[parameters('sqlDbPass')]"
+                }
+              ]
+            }
+          }
+        ],
+        "osType": "Linux",
+        "ipAddress": {
+          "type": "Public",
+          "ports": [
+            {
+              "protocol": "TCP",
+              "port": 1433
+            },
+            {
+              "protocol": "TCP",
+              "port": 3306
+            }
+          ],
+          "dnsNameLabel": "[variables('dbContainerName')]"
+        }
+      }
+    },
+    {
+      "name": "[variables('containerName')]",
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2021-07-01",
+      "location": "westus2",
+      "properties": {
+        "containers": [
+          {
+            "name": "citest-mssql",
+            "properties": {
+              "image": "etheos.azurecr.io/etheos/ci-test",
+              "resources": {
+                "requests": {
+                  "cpu": 1.0,
+                  "memoryInGB": 0.5
+                }
+              },
+              "ports": [
+                {
+                  "port": 8078
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "name": "logs",
+                  "mountPath": "/logs"
+                },
+                {
+                  "name": "data",
+                  "mountPath": "/etheos/data"
+                }
+              ],
+              "environmentVariables": [
+                {
+                  "name": "ETHEOS_PORT",
+                  "value": "8078"
+                },
+                {
+                  "name": "ETHEOS_DBTYPE",
+                  "value": "sqlserver"
+                },
+                {
+                  "name": "ETHEOS_DBPASS",
+                  "secureValue": "[parameters('sqlDbPass')]"
+                },
+                {
+                  "name": "ETHEOS_LOGOUT",
+                  "value": "/logs/ci-test/stdout-mssql"
+                },
+                {
+                  "name": "ETHEOS_LOGERR",
+                  "value": "/logs/ci-test/stderr-mssql"
+                },
+                {
+                  "name": "ETHEOS_WORLDDUMPFILE",
+                  "value": "/logs/ci-test/world.mssql.bak.json"
+                },
+                {
+                  "name": "ETHEOS_DBNAME",
+                  "value": "etheos_ci_test"
+                },
+                {
+                  "name": "ETHEOS_DBHOST",
+                  "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups', variables('dbContainerName'))).ipAddress.ip]"
+                },
+                {
+                  "name": "ETHEOS_DBPORT",
+                  "value": "1433"
+                },
+                {
+                  "name": "ETHEOS_DBUSER",
+                  "value": "sa"
+                },
+                {
+                  "name": "ETHEOS_BCRYPTWORKLOAD",
+                  "value": "12"
+                },
+                {
+                  "name": "ETHEOS_THREADPOOLTHREADS",
+                  "value": "4"
+                },
+                {
+                  "name": "ETHEOS_LOGCONNECTION",
+                  "value": "1"
+                },
+                {
+                  "name": "ETHEOS_AUTOCREATEDATABASE",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          {
+            "name": "citest-mysql",
+            "properties": {
+              "image": "etheos.azurecr.io/etheos/ci-test",
+              "resources": {
+                "requests": {
+                  "cpu": 1.0,
+                  "memoryInGB": 0.5
+                }
+              },
+              "ports": [
+                {
+                  "port": 9078
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "name": "logs",
+                  "mountPath": "/logs"
+                },
+                {
+                  "name": "data",
+                  "mountPath": "/etheos/data"
+                }
+              ],
+              "environmentVariables": [
+                {
+                  "name": "ETHEOS_PORT",
+                  "value": "9078"
+                },
+                {
+                  "name": "ETHEOS_DBTYPE",
+                  "value": "mysql"
+                },
+                {
+                  "name": "ETHEOS_DBPASS",
+                  "secureValue": "[parameters('sqlDbPass')]"
+                },
+                {
+                  "name": "ETHEOS_LOGOUT",
+                  "value": "/logs/ci-test/stdout-mysql"
+                },
+                {
+                  "name": "ETHEOS_LOGERR",
+                  "value": "/logs/ci-test/stderr-mysql"
+                },
+                {
+                  "name": "ETHEOS_WORLDDUMPFILE",
+                  "value": "/logs/ci-test/world.mysql.bak.json"
+                },
+                {
+                  "name": "ETHEOS_DBNAME",
+                  "value": "etheos_ci_test"
+                },
+                {
+                  "name": "ETHEOS_DBHOST",
+                  "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups', variables('dbContainerName'))).ipAddress.ip]"
+                },
+                {
+                  "name": "ETHEOS_DBPORT",
+                  "value": "3306"
+                },
+                {
+                  "name": "ETHEOS_DBUSER",
+                  "value": "root"
+                },
+                {
+                  "name": "ETHEOS_BCRYPTWORKLOAD",
+                  "value": "12"
+                },
+                {
+                  "name": "ETHEOS_THREADPOOLTHREADS",
+                  "value": "4"
+                },
+                {
+                  "name": "ETHEOS_LOGCONNECTION",
+                  "value": "1"
+                },
+                {
+                  "name": "ETHEOS_AUTOCREATEDATABASE",
+                  "value": "true"
+                },
+                {
+                  "name": "ETHEOS_INSTALLSQL",
+                  "value": "./install.sql"
+                }
+              ]
+            }
+          },
+          {
+            "name": "citest-sqlite",
+            "properties": {
+              "image": "etheos.azurecr.io/etheos/ci-test",
+              "resources": {
+                "requests": {
+                  "cpu": 1.0,
+                  "memoryInGB": 0.5
+                }
+              },
+              "ports": [
+                {
+                  "port": 10078
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "name": "logs",
+                  "mountPath": "/logs"
+                },
+                {
+                  "name": "data",
+                  "mountPath": "/etheos/data"
+                }
+              ],
+              "environmentVariables": [
+                {
+                  "name": "ETHEOS_PORT",
+                  "value": "10078"
+                },
+                {
+                  "name": "ETHEOS_DBTYPE",
+                  "value": "sqlite"
+                },
+                {
+                  "name": "ETHEOS_DBHOST",
+                  "value": "/etheos/citest.sdb"
+                },
+                {
+                  "name": "ETHEOS_LOGOUT",
+                  "value": "/logs/ci-test/stdout-sqlite"
+                },
+                {
+                  "name": "ETHEOS_LOGERR",
+                  "value": "/logs/ci-test/stderr-sqlite"
+                },
+                {
+                  "name": "ETHEOS_WORLDDUMPFILE",
+                  "value": "/logs/ci-test/world.sqlite.bak.json"
+                },
+                {
+                  "name": "ETHEOS_BCRYPTWORKLOAD",
+                  "value": "12"
+                },
+                {
+                  "name": "ETHEOS_THREADPOOLTHREADS",
+                  "value": "4"
+                },
+                {
+                  "name": "ETHEOS_LOGCONNECTION",
+                  "value": "1"
+                },
+                {
+                  "name": "ETHEOS_INSTALLSQL",
+                  "value": "./install.sql"
+                }
+              ]
+            }
+          }
+        ],
+        "imageRegistryCredentials": [
+          {
+            "server": "etheos.azurecr.io",
+            "username": "etheos",
+            "password": "[parameters('imageRegistryPass')]"
+          }
+        ],
+        "osType": "Linux",
+        "ipAddress": {
+          "type": "Public",
+          "ports": [
+            {
+              "protocol": "TCP",
+              "port": 8078
+            },
+            {
+              "protocol": "TCP",
+              "port": 9078
+            },
+            {
+              "protocol": "TCP",
+              "port": 10078
+            }
+          ],
+          "dnsNameLabel": "[variables('containerName')]"
+        },
+        "volumes": [
+          {
+            "name": "logs",
+            "azureFile": {
+              "shareName": "etheos-logs",
+              "storageAccountName": "[parameters('storageAccountName')]",
+              "storageAccountKey": "[parameters('storageAccountKey')]",
+              "readOnly": false
+            }
+          },
+          {
+            "name": "data",
+            "azureFile": {
+              "shareName": "etheos-sample-data",
+              "storageAccountName": "[parameters('storageAccountName')]",
+              "storageAccountKey": "[parameters('storageAccountKey')]",
+              "readOnly": true
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ContainerInstance/containerGroups', variables('dbContainerName'))]"
+      ]
+    }
+  ]
+}

--- a/deploy/etheos-container.json
+++ b/deploy/etheos-container.json
@@ -16,7 +16,6 @@
       "allowedValues": [
         "dev",
         "test",
-        "ci-test",
         "prod"
       ]
     },

--- a/deploy/params-ci-test.json
+++ b/deploy/params-ci-test.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "sqlDbPass": {
+            "reference": {
+                "keyVault": {
+                    "id": "/subscriptions/98f6bee3-15b1-4f55-85cd-360437f1b225/resourceGroups/etheos/providers/Microsoft.KeyVault/vaults/etheos-vault"
+                },
+                "secretName": "sqlDbPass"
+            }
+        },
+        "imageRegistryPass": {
+            "reference": {
+                "keyVault": {
+                    "id": "/subscriptions/98f6bee3-15b1-4f55-85cd-360437f1b225/resourceGroups/etheos/providers/Microsoft.KeyVault/vaults/etheos-vault"
+                },
+                "secretName": "imageRegistryPass"
+            }
+        },
+        "storageAccountName": {
+            "value": "etheosstorage"
+        },
+        "storageAccountKey": {
+            "reference": {
+                "keyVault": {
+                    "id": "/subscriptions/98f6bee3-15b1-4f55-85cd-360437f1b225/resourceGroups/etheos/providers/Microsoft.KeyVault/vaults/etheos-vault"
+                },
+                "secretName": "storageAccountKey"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Deploys to separate environment in azure. Relies on databases that are also deployed (as containers) via the ARM template. ARM template for dev/test/prod no longer supports deploying to ci-test since the ci-test files are now separate.