### PR TITLE
Tear down CI environment when not in use. Reduces Azure spend.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,14 +131,17 @@ stages:
     steps:
     - checkout: self
       lfs: true
-    - script: $(Build.SourcesDirectory)/deploy/deploy.sh -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e dev
+    - script: $(Build.SourcesDirectory)/deploy/deploy.sh CREATE -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e dev
       condition: not(eq(variables['Build.Reason'], 'IndividualCI'))
       displayName: 'PR/Manual Builds - Deploy to dev environment'
-    - script: $(Build.SourcesDirectory)/deploy/deploy.sh -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e ci-test -g etheos --template-file $(Build.SourcesDirectory)/deploy/etheos-ci-test.json --parameter-file $(Build.SourcesDirectory)/deploy/params-ci-test.json
+    - script: $(Build.SourcesDirectory)/deploy/deploy.sh CREATE -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e ci-test -g etheos --template-file $(Build.SourcesDirectory)/deploy/etheos-ci-test.json --parameter-file $(Build.SourcesDirectory)/deploy/params-ci-test.json
       condition: eq(variables['Build.Reason'], 'IndividualCI')
       displayName: 'CI Builds - Deploy to ci-test environment'
     # TODO: run CI tests, only build/deploy test image on success
     #
+    - script: $(Build.SourcesDirectory)/deploy/deploy.sh DELETE -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e ci-test -g etheos --template-file $(Build.SourcesDirectory)/deploy/etheos-ci-test.json --parameter-file $(Build.SourcesDirectory)/deploy/params-ci-test.json
+      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      displayName: 'CI Builds - Delete ci-test environment'
     - task: DownloadBuildArtifacts@0
       condition: eq(variables['Build.Reason'], 'IndividualCI')
       inputs:
@@ -165,6 +168,6 @@ stages:
         tags: |
           $(Build.BuildNumber)
           latest
-    - script: $(Build.SourcesDirectory)/deploy/deploy.sh -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e test
+    - script: $(Build.SourcesDirectory)/deploy/deploy.sh CREATE -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e test
       condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'))
       displayName: 'Successful CI Builds - Deploy to test environment'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,7 @@ stages:
       condition: eq(variables['Build.Reason'], 'IndividualCI')
       displayName: 'CI Builds - Test connection to server'
     - script: $(Build.SourcesDirectory)/deploy/deploy.sh DELETE -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e ci-test -g etheos --template-file $(Build.SourcesDirectory)/deploy/etheos-ci-test.json --parameter-file $(Build.SourcesDirectory)/deploy/params-ci-test.json
-      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      condition: and(eq(variables['Build.Reason'], 'IndividualCI'), succeededOrFailed())
       displayName: 'CI Builds - Delete ci-test environment'
     - task: DownloadBuildArtifacts@0
       condition: eq(variables['Build.Reason'], 'IndividualCI')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,7 +138,11 @@ stages:
       condition: eq(variables['Build.Reason'], 'IndividualCI')
       displayName: 'CI Builds - Deploy to ci-test environment'
     # TODO: run CI tests, only build/deploy test image on success
+    # For now just use a simple script to test that we can connect
     #
+    - script: python3 $(Build.SourcesDirectory)/deploy/test-connection.py ci-test.etheos.moffat.io 8078 9078 10078
+      condition: eq(variables['Build.Reason'], 'IndividualCI')
+      displayName: 'CI Builds - Test connection to server'
     - script: $(Build.SourcesDirectory)/deploy/deploy.sh DELETE -u 55d02cce-765c-4364-a5a6-1328ba987d83 -p $(deployAppSecret) -e ci-test -g etheos --template-file $(Build.SourcesDirectory)/deploy/etheos-ci-test.json --parameter-file $(Build.SourcesDirectory)/deploy/params-ci-test.json
       condition: eq(variables['Build.Reason'], 'IndividualCI')
       displayName: 'CI Builds - Delete ci-test environment'

--- a/deploy/test-connection.py
+++ b/deploy/test-connection.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+
+import socket
+import sys
+
+def connect_to(host, port):
+    try:
+        return socket.create_connection((host, port))
+    except:
+        print(f"Socket connection to {host}:{port} failed!\n")
+        return None
+
+def check_socket_and_close(socketInstance):
+    if (socketInstance):
+        print("OK\n")
+        socketInstance.close()
+    else:
+        print("FAILED\n")
+        exit(1)
+
+socket.setdefaulttimeout(10)
+
+if len(sys.argv) <= 2:
+    print("Usage: python test-connection.py <host> <port1> [port2]..[portN]")
+
+host = sys.argv[1]
+portNdx = 2
+
+while len(sys.argv) > portNdx:
+    port = sys.argv[portNdx]
+    print(f"Testing connection to {host}:{port}...")
+    socketInstance = connect_to(host, port)
+    check_socket_and_close(socketInstance)
+    portNdx = portNdx + 1


### PR DESCRIPTION
Got hit with a rather large Azure spend bill due to the CI test environment always being up. Since it isn't really necessary to have up all the time I think it's safe to tear it down when it isn't actively being used. This adds a step to the build to tear down the CI test environment after CI tests run.