### PR TITLE
Add support for log file rotation

### DIFF
--- a/.pipelines/azure-pipelines-ci.yml
+++ b/.pipelines/azure-pipelines-ci.yml
@@ -1,5 +1,6 @@
 name: 0.7.1_$(Year:yyyy).$(Month).$(DayOfMonth)_$(SourceBranchName)
 
+pr: none
 trigger: none
 
 resources:

--- a/.pipelines/azure-pipelines-deploy-test.yml
+++ b/.pipelines/azure-pipelines-deploy-test.yml
@@ -1,5 +1,6 @@
 name: 0.7.1_$(Year:yyyy).$(Month).$(DayOfMonth)_$(SourceBranchName)
 
+pr: none
 trigger: none
 
 resources:

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -21,7 +21,7 @@
             ],
             "compilerPath": "\"${myCompilerPath}cl.exe\"",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -48,7 +48,7 @@
             ],
             "compilerPath": "\"${myCompilerPath}cl.exe\"",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -74,7 +74,7 @@
             ],
             "compilerPath": "\"${myCompilerPath}cl.exe\"",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -98,7 +98,7 @@
             ],
             "compilerPath": "/usr/bin/g++",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -123,7 +123,7 @@
             ],
             "compilerPath": "/usr/bin/g++",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -147,7 +147,7 @@
             ],
             "compilerPath": "/usr/bin/g++",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -173,7 +173,7 @@
             ],
             "compilerPath": "\"${myCompilerPath}cl.exe\"",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -201,7 +201,7 @@
             ],
             "compilerPath": "\"${myCompilerPath}cl.exe\"",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -228,7 +228,7 @@
             ],
             "compilerPath": "\"${myCompilerPath}cl.exe\"",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -253,7 +253,7 @@
             ],
             "compilerPath": "/usr/bin/g++",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -279,7 +279,7 @@
             ],
             "compilerPath": "/usr/bin/g++",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"
@@ -304,7 +304,7 @@
             ],
             "compilerPath": "/usr/bin/g++",
             "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cppStandard": "c++17",
             "browse": {
                 "path": [
                     "${workspaceFolder}"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,7 @@
         {
             "name": "Debug - Linux",
             "preLaunchTask": "Build (Linux) - Debug",
-            "type": "cppvsdbg",
+            "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/install/etheos",
             "args": [],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # EOSERV is released under the zlib license.
 # See LICENSE.txt for more info.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.9)
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0054 NEW)
 
@@ -117,9 +117,11 @@ if(eoserv_GCC OR eoserv_CLANG)
 		if(eoserv_CXX1Y)
 			set(eoserv_STDFLAG "-std=c++1y")
 		else()
-			set(eoserv_STDFLAG "-std=c++14")
+			set(eoserv_STDFLAG "-std=c++17")
 		endif()
 	endif()
+else()
+	set(eoserv_STDFLAG "/std:c++17")
 endif()
 
 if(eoserv_STDFLAG)

--- a/config/console.ini
+++ b/config/console.ini
@@ -4,15 +4,34 @@
 
 ### CONSOLE OPTIONS ###
 
+## EnableLogRotation (bool)
+# True to enable log rotation. See the below settings for more control over log rotation.
+# True implies logging to files. Filenames will be auto-generated and stored in LogFileDirectory.
+EnableLogRotation = false
+
 ## LogOut (string)
-# Filename to log normal output
+# Filename to log normal output when log rotation is disabled
 # Use - for console output
 LogOut = -
 
 ## LogErr (string)
-# Filename to log errors
+# Filename to log errors when log rotation is disabled
 # Use - for console output
 LogErr = error.log
+
+## LogRotationSize (int)
+# Log file size in bytes before rolling over to next log file
+# 0 disables rollover by file size
+LogRotationSize = 0
+
+## LogRotationInterval (number)
+# Time to wait before rolling over to the next log file
+# 0 disables rolllover by time
+LogRotationInterval = 1h
+
+## LogFileDirectory (string)
+# Path to where log files should be stored when log rotation is enabled
+LogFileDirectory = logs
 
 ## StyleConsole (bool)
 # Uses pretty colors for Out/Warn/Error/Debug

--- a/config/console.ini
+++ b/config/console.ini
@@ -29,6 +29,11 @@ LogRotationSize = 0
 # 0 disables rolllover by time
 LogRotationInterval = 1h
 
+## LogFileLimit (int)
+# Maximum number of old files to keep
+# 0 disables delete of old logs
+LogFileLimit = 10
+
 ## LogFileDirectory (string)
 # Path to where log files should be stored when log rotation is enabled
 LogFileDirectory = logs

--- a/deploy/etheos-container.json
+++ b/deploy/etheos-container.json
@@ -80,12 +80,24 @@
                   "secureValue": "[parameters('sqlDbPass')]"
                 },
                 {
-                  "name": "ETHEOS_LOGOUT",
-                  "value": "[concat('/logs/', parameters('environmentName'), '/stdout')]"
+                  "name": "ETHEOS_ENABLELOGROTATION",
+                  "value": "true"
                 },
                 {
-                  "name": "ETHEOS_LOGERR",
-                  "value": "[concat('/logs/', parameters('environmentName'), '/stderr')]"
+                  "name": "ETHEOS_LOGROTATIONINTERVAL",
+                  "value": "1d"
+                },
+                {
+                  "name": "ETHEOS_LOGFILELIMIT",
+                  "value": "7"
+                },
+                {
+                  "name": "ETHEOS_LOGFILEDIRECTORY",
+                  "value": "[concat('/logs/', parameters('environmentName'))]"
+                },
+                {
+                  "name": "ETHEOS_LOGCONNECTION",
+                  "value": "1"
                 },
                 {
                   "name": "ETHEOS_WORLDDUMPFILE",
@@ -110,10 +122,6 @@
                 {
                   "name": "ETHEOS_THREADPOOLTHREADS",
                   "value": "4"
-                },
-                {
-                  "name": "ETHEOS_LOGCONNECTION",
-                  "value": "1"
                 }
               ]
             }

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -25,8 +25,8 @@
 
 namespace fs = std::filesystem;
 
-std::mutex Console::output_lock = std::mutex();
-std::mutex Console::error_lock = std::mutex();
+// std::mutex Console::output_lock = std::mutex();
+// std::mutex Console::error_lock = std::mutex();
 
 bool Console::Styled[2] = { true, true };
 
@@ -138,7 +138,7 @@ void Console::Out(const char* f, ...)
 {
 	if (OutputSuppressed) return;
 
-	std::lock_guard<std::mutex> queueGuard(output_lock);
+	// std::lock_guard<std::mutex> queueGuard(output_lock);
 
 	va_list args;
 	va_start(args, f);
@@ -150,7 +150,7 @@ void Console::Wrn(const char* f, ...)
 {
 	if (OutputSuppressed) return;
 
-	std::lock_guard<std::mutex> queueGuard(output_lock);
+	// std::lock_guard<std::mutex> queueGuard(output_lock);
 
 	va_list args;
 	va_start(args, f);
@@ -163,7 +163,7 @@ void Console::Err(const char* f, ...)
 	if (OutputSuppressed)
 		return;
 
-	std::lock_guard<std::mutex> queueGuard(error_lock);
+	// std::lock_guard<std::mutex> queueGuard(error_lock);
 
 	if (!Styled[STREAM_ERR])
 	{
@@ -183,7 +183,7 @@ void Console::Dbg(const char* f, ...)
 {
 	if (OutputSuppressed) return;
 
-	std::lock_guard<std::mutex> queueGuard(output_lock);
+	// std::lock_guard<std::mutex> queueGuard(output_lock);
 
 	va_list args;
 	va_start(args, f);

--- a/src/console.hpp
+++ b/src/console.hpp
@@ -52,7 +52,9 @@ public:
 	static void Dbg(const char* f, ...);
 
 	static void SuppressOutput(bool suppress);
-	static void SetRollover(size_t bytesPerFile, time_t interval);
+
+	static void SetLog(Stream stream, const std::string& fileName);
+	static void SetRollover(size_t bytesPerFile, time_t interval, const std::string& format);
 };
 
 #endif // CONSOLE_HPP_INCLUDED

--- a/src/console.hpp
+++ b/src/console.hpp
@@ -34,14 +34,23 @@ public:
 	};
 
 private:
-	static size_t BytesWritten[2];
+	static struct RotationProperties
+	{
+		bool enabled;
+		size_t bytes_per_file;
+		unsigned interval_in_seconds;
+		std::string target_directory;
+	} rotation_properties;
+
+	static size_t bytes_written[2];
+	static double first_write_time[2];
 	static bool OutputSuppressed;
 
 	static inline void Init(Stream i);
 	static inline void SetTextColor(Stream stream, Color color, bool bold);
 	static inline void ResetTextColor(Stream stream);
 
-	static inline size_t GenericOut(const std::string& prefix, Stream stream, Color color, bool bold, const char * format, va_list args);
+	static inline void GenericOut(const std::string& prefix, Stream stream, Color color, bool bold, const char * format, va_list args);
 
 public:
 	static bool Styled[2];
@@ -54,7 +63,9 @@ public:
 	static void SuppressOutput(bool suppress);
 
 	static void SetLog(Stream stream, const std::string& fileName);
-	static void SetRollover(size_t bytesPerFile, time_t interval, const std::string& format);
+	static void SetRotation(size_t bytesPerFile, unsigned interval, const std::string& format);
+	static bool TryGetLatestRotatedLogFileName(Stream stream, std::string& file_name);
+	static bool TryGetNextRotatedLogFileName(Stream stream, std::string& file_name);
 };
 
 #endif // CONSOLE_HPP_INCLUDED

--- a/src/console.hpp
+++ b/src/console.hpp
@@ -11,6 +11,7 @@
 
 #include <cstdarg>
 #include <string>
+#include <mutex>
 
 class Console
 {
@@ -42,6 +43,8 @@ private:
 		std::string target_directory;
 		size_t file_limit;
 	} rotation_properties;
+
+	static std::mutex output_lock, error_lock;
 
 	static size_t bytes_written[2];
 	static double first_write_time[2];

--- a/src/console.hpp
+++ b/src/console.hpp
@@ -9,38 +9,50 @@
 
 #include "fwd/console.hpp"
 
+#include <cstdarg>
 #include <string>
 
-namespace Console
+class Console
 {
+public:
+	enum Color
+	{
+		COLOR_BLUE = 1,
+		COLOR_GREEN = 2,
+		COLOR_CYAN = 3,
+		COLOR_RED = 4,
+		COLOR_MAGENTA = 5,
+		COLOR_YELLOW = 6,
+		COLOR_GREY = 7,
+		COLOR_BLACK = 8
+	};
 
-extern bool Styled[2];
+	enum Stream
+	{
+		STREAM_OUT,
+		STREAM_ERR
+	};
 
-enum Color
-{
-	COLOR_BLUE = 1,
-	COLOR_GREEN = 2,
-	COLOR_CYAN = 3,
-	COLOR_RED = 4,
-	COLOR_MAGENTA = 5,
-	COLOR_YELLOW = 6,
-	COLOR_GREY = 7,
-	COLOR_BLACK = 8
+private:
+	static size_t BytesWritten[2];
+	static bool OutputSuppressed;
+
+	static inline void Init(Stream i);
+	static inline void SetTextColor(Stream stream, Color color, bool bold);
+	static inline void ResetTextColor(Stream stream);
+
+	static inline size_t GenericOut(const std::string& prefix, Stream stream, Color color, bool bold, const char * format, va_list args);
+
+public:
+	static bool Styled[2];
+
+	static void Out(const char* f, ...);
+	static void Wrn(const char* f, ...);
+	static void Err(const char* f, ...);
+	static void Dbg(const char* f, ...);
+
+	static void SuppressOutput(bool suppress);
+	static void SetRollover(size_t bytesPerFile, time_t interval);
 };
-
-enum Stream
-{
-	STREAM_OUT,
-	STREAM_ERR
-};
-
-void Out(const char* f, ...);
-void Wrn(const char* f, ...);
-void Err(const char* f, ...);
-void Dbg(const char* f, ...);
-
-void SuppressOutput(bool suppress);
-
-}
 
 #endif // CONSOLE_HPP_INCLUDED

--- a/src/console.hpp
+++ b/src/console.hpp
@@ -40,6 +40,7 @@ private:
 		size_t bytes_per_file;
 		unsigned interval_in_seconds;
 		std::string target_directory;
+		size_t file_limit;
 	} rotation_properties;
 
 	static size_t bytes_written[2];
@@ -52,6 +53,8 @@ private:
 
 	static inline void GenericOut(const std::string& prefix, Stream stream, Color color, bool bold, const char * format, va_list args);
 
+	static inline void DeleteOldestIfNeeded(Stream stream);
+
 public:
 	static bool Styled[2];
 
@@ -63,8 +66,7 @@ public:
 	static void SuppressOutput(bool suppress);
 
 	static void SetLog(Stream stream, const std::string& fileName);
-	static void SetRotation(size_t bytesPerFile, unsigned interval, const std::string& format);
-	static bool TryGetLatestRotatedLogFileName(Stream stream, std::string& file_name);
+	static void SetRotation(size_t bytesPerFile, unsigned interval, const std::string& directory, size_t fileLimit);
 	static bool TryGetNextRotatedLogFileName(Stream stream, std::string& file_name);
 };
 

--- a/src/console.hpp
+++ b/src/console.hpp
@@ -11,7 +11,7 @@
 
 #include <cstdarg>
 #include <string>
-#include <mutex>
+// #include <mutex>
 
 class Console
 {
@@ -44,7 +44,7 @@ private:
 		size_t file_limit;
 	} rotation_properties;
 
-	static std::mutex output_lock, error_lock;
+	// static std::mutex output_lock, error_lock;
 
 	static size_t bytes_written[2];
 	static double first_write_time[2];

--- a/src/console.hpp
+++ b/src/console.hpp
@@ -56,6 +56,8 @@ private:
 
 	static inline void GenericOut(const std::string& prefix, Stream stream, Color color, bool bold, const char * format, va_list args);
 
+	static inline std::string GetTimeString(const std::string& date_sep, const std::string& split_sep, const std::string& time_sep);
+
 	static inline void DeleteOldestIfNeeded(Stream stream);
 
 public:

--- a/src/eoserv_config.cpp
+++ b/src/eoserv_config.cpp
@@ -27,8 +27,13 @@ static void eoserv_config_default(Config& config, const char* key, T value)
 
 void eoserv_config_validate_config(Config& config)
 {
+	eoserv_config_default(config, "EnableLogRotation"  , false);
 	eoserv_config_default(config, "LogOut"             , "-");
 	eoserv_config_default(config, "LogErr"             , "error.log");
+	eoserv_config_default(config, "LogRotationSize"    , 0);
+	eoserv_config_default(config, "LogRotationInterval", 0);
+	eoserv_config_default(config, "LogFileLimit"       , 10);
+	eoserv_config_default(config, "LogFileDirectory"   , "logs");
 	eoserv_config_default(config, "StyleConsole"       , true);
 	eoserv_config_default(config, "LogCommands"        , true);
 	eoserv_config_default(config, "LogConnection"      , 0);

--- a/src/fwd/console.hpp
+++ b/src/fwd/console.hpp
@@ -9,14 +9,6 @@
 
 #include <string>
 
-namespace Console
-{
-
-void Out(const char* f, ...);
-void Wrn(const char* f, ...);
-void Err(const char* f, ...);
-void Dbg(const char* f, ...);
-
-};
+class Console;
 
 #endif // FWD_CONFIG_HPP_INCLUDED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -293,52 +293,8 @@ int eoserv_main(int argc, char *argv[])
 		Console::Wrn("This is a debug build and shouldn't be used for live servers.");
 #endif
 
-		{
-			std::time_t rawtime;
-			char timestr[256];
-			std::time(&rawtime);
-			std::strftime(timestr, 256, "%c", std::localtime(&rawtime));
-
-			std::string logerr = config["LogErr"];
-			if (!logerr.empty() && logerr.compare("-") != 0)
-			{
-				Console::Out("Redirecting errors to '%s'...", logerr.c_str());
-				if (!std::freopen(logerr.c_str(), "a", stderr))
-				{
-					Console::Err("Failed to redirect errors.");
-				}
-				else
-				{
-					Console::Styled[Console::STREAM_ERR] = false;
-					std::fprintf(stderr, "\n\n--- %s ---\n\n", timestr);
-				}
-
-				if (std::setvbuf(stderr, 0, _IONBF, 0) != 0)
-				{
-					Console::Wrn("Failed to change stderr buffer settings");
-				}
-			}
-
-			std::string logout = config["LogOut"];
-			if (!logout.empty() && logout.compare("-") != 0)
-			{
-				Console::Out("Redirecting output to '%s'...", logout.c_str());
-				if (!std::freopen(logout.c_str(), "a", stdout))
-				{
-					Console::Err("Failed to redirect output.");
-				}
-				else
-				{
-					Console::Styled[Console::STREAM_OUT] = false;
-					std::printf("\n\n--- %s ---\n\n", timestr);
-				}
-
-				if (std::setvbuf(stdout, 0, _IONBF, 0) != 0)
-				{
-					Console::Wrn("Failed to change stdout buffer settings");
-				}
-			}
-		}
+		Console::SetLog(Console::STREAM_OUT, config["LogOut"].GetString());
+		Console::SetLog(Console::STREAM_ERR, config["LogErr"].GetString());
 
 		const auto threadPoolThreads = static_cast<int>(config["ThreadPoolThreads"]);
 		if (threadPoolThreads <= 0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -293,6 +293,28 @@ int eoserv_main(int argc, char *argv[])
 		Console::Wrn("This is a debug build and shouldn't be used for live servers.");
 #endif
 
+		if (config["EnableLogRotation"])
+		{
+			auto sizeInBytes = static_cast<size_t>(std::max(0, config["LogRotationSize"].GetInt()));
+			auto interval = static_cast<unsigned>(std::max(0, config["LogRotationInterval"].GetInt()));
+			auto directory = config["LogFileDirectory"].GetString();
+
+			if (sizeInBytes == 0 && interval == 0)
+			{
+				Console::Wrn("Log rotation by size and time interval are both unset. Log files will not be rotated.");
+			}
+			else
+			{
+				Console::SetRotation(sizeInBytes, interval, directory);
+
+				std::string tmp;
+				if (Console::TryGetLatestRotatedLogFileName(Console::STREAM_OUT, tmp))
+					config["LogOut"] = tmp;
+				if (Console::TryGetLatestRotatedLogFileName(Console::STREAM_ERR, tmp))
+					config["LogErr"] = tmp;
+			}
+		}
+
 		Console::SetLog(Console::STREAM_OUT, config["LogOut"].GetString());
 		Console::SetLog(Console::STREAM_ERR, config["LogErr"].GetString());
 

--- a/src/socket.hpp
+++ b/src/socket.hpp
@@ -201,7 +201,7 @@ class IPAddress
 
 namespace std
 {
-	template <> struct hash<IPAddress> : public unary_function<IPAddress, std::size_t>
+	template <> struct hash<IPAddress>
 	{
 		std::size_t operator()(const IPAddress &ipaddress) const
 		{

--- a/src/util/threadpool.cpp
+++ b/src/util/threadpool.cpp
@@ -15,7 +15,11 @@ namespace util
 {
     // These are initialized here to allow tests to compile on Ubuntu Linux (g++ 7.4.0)
     // Otherwise, they aren't in the object file in unity build mode and test linking fails
+
+    // Maximum number of threadpool threads is arbitrarily defined at 32 because it is highly unlikely there will be more than 32 cores in a system running etheos
     const size_t ThreadPool::MAX_THREADS = 32;
+
+    // Default number of threads is arbitrarily defined at 4 because it is highly unlikely there will be more than 4 concurrent ThreadPool operations on most setups
     const size_t ThreadPool::DEFAULT_THREADS = 4;
 
     // There should really only be a single thread pool per application


### PR DESCRIPTION
Options are as follows:
- Rotate by file size
- Rotate by time interval
- Limit the number of old files that are kept around
- Set the log directory

Rotation will occur on either file size or time interval. Rotation is disabled if file size/interval are both unset.

Example configuration (from dev/test instances) - rotate daily, keeping 7 total files (week's worth of logs)
```ini
EnableLogRotation=true
LogRotationSize=0
LogRotationInterval=1d
LogFileLimit=7
LogFileDirectory=/logs/{env}
```

LogOut and LogErr are both ignored when log rotation is enabled.

Potentially undesirable behavior:
~1. Only one log file is deleted when log file limit is set, instead of all files over the limit number.~ Fixed in 8a406f5967da356b2e69c752f6a2334e4dabba05
2. Most recent existing log file is not opened in append mode on application start.