### PR TITLE
Fix bug where `TalkedToNpc` breaks for NPC vendor IDs above 127

### DIFF
--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -1054,7 +1054,7 @@ bool Quest_Context::DialogInput(char link_id)
 	return this->TriggerRule("inputnpc", [link_id](const std::deque<util::variant>& args) { return int(args[0]) == link_id; });
 }
 
-bool Quest_Context::TalkedNPC(char vendor_id)
+bool Quest_Context::TalkedNPC(short vendor_id)
 {
 	if (this->quest->Disabled())
 		return false;

--- a/src/quest.hpp
+++ b/src/quest.hpp
@@ -76,7 +76,7 @@ class Quest_Context : public EOPlus::Context
 		std::string::const_iterator UnserializeProgress(std::string::const_iterator it, std::string::const_iterator begin);
 
 		bool DialogInput(char link_id);
-		bool TalkedNPC(char vendor_id);
+		bool TalkedNPC(short vendor_id);
 
 		void UsedItem(short id);
 		void UsedSpell(short id);


### PR DESCRIPTION
Trivial fix for an oversight in the data type used for `Quest_Context::TalkedNPC`.
See: https://eoserv.net/bugs/view_bug/444