### PR TITLE
Fix MSVC debug asserts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "preLaunchTask": "Build (Windows) - Debug",
             "type": "cppvsdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/install/etheos",
+            "program": "${workspaceFolder}/install/etheos.exe",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/install",
@@ -21,7 +21,7 @@
             "preLaunchTask": "Build (Windows) - Debug",
             "type": "cppvsdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/install/test/eoserv_test",
+            "program": "${workspaceFolder}/install/test/eoserv_test.exe",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/install/test",
@@ -31,14 +31,14 @@
         {
             "name": "Debug - Linux",
             "preLaunchTask": "Build (Linux) - Debug",
-            "type": "cppvsdbg",
+            "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/install/etheos",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/install",
             "environment": [],
-            "console": "internalConsole"
+            "externalConsole": false
         }
     ]
 }

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -399,9 +399,10 @@ unsigned int PacketReader::GetNumber(std::size_t length)
 {
 	std::array<unsigned char, 4> bytes{{254, 254, 254, 254}};
 
-	std::copy_n(util::cbegin(this->data) + this->pos, std::min(length, this->Remaining()), util::begin(bytes));
+	size_t read_len = std::min(length, this->Remaining());
+	std::copy_n(util::cbegin(this->data) + this->pos, read_len, util::begin(bytes));
 
-	this->pos += length;
+	this->pos += read_len;
 
 	return PacketProcessor::Number(bytes[0], bytes[1], bytes[2], bytes[3]);
 }

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -334,10 +334,10 @@ void Client::Bind(const IPAddress &addr, uint16_t port)
 	sockaddr_in sin;
 	uint16_t portn = htons(port);
 
-	const char yes = 1;
+	const int yes = 1;
 #ifdef WIN32
-	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
-	setsockopt(this->impl->sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, &yes, sizeof(int));
+	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&yes), sizeof(int));
+	setsockopt(this->impl->sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, reinterpret_cast<const char*>(&yes), sizeof(int));
 #else
 	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
 	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(int));
@@ -647,10 +647,10 @@ void Server::Bind(const IPAddress &addr, uint16_t port)
 	sin.sin_addr.s_addr = htonl(this->address);
 	sin.sin_port = this->portn;
 
-	const char yes = 1;
+	const int yes = 1;
 #ifdef WIN32
-	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
-	setsockopt(this->impl->sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, &yes, sizeof(int));
+	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&yes), sizeof(int));
+	setsockopt(this->impl->sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, reinterpret_cast<const char*>(&yes), sizeof(int));
 #else
 	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
 	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(int));

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -334,9 +334,10 @@ void Client::Bind(const IPAddress &addr, uint16_t port)
 	sockaddr_in sin;
 	uint16_t portn = htons(port);
 
-	int yes = 1;
+	const char yes = 1;
 #ifdef WIN32
-	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, (const char*)yes, sizeof(int));
+	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
+	setsockopt(this->impl->sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, &yes, sizeof(int));
 #else
 	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
 	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(int));
@@ -646,9 +647,10 @@ void Server::Bind(const IPAddress &addr, uint16_t port)
 	sin.sin_addr.s_addr = htonl(this->address);
 	sin.sin_port = this->portn;
 
-	int yes = 1;
+	const char yes = 1;
 #ifdef WIN32
-	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, (const char*)yes, sizeof(int));
+	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
+	setsockopt(this->impl->sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, &yes, sizeof(int));
 #else
 	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int));
 	setsockopt(this->impl->sock, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(int));


### PR DESCRIPTION
Addresses two asserts that show up when debugging on windows
1. `setsockopt` was incorrectly casting the value of `1` to `char *` and passing this as the `optval` parameter. Instead, the address of the `1` value is passed
2. `GetNumber` during packet reading was incorrectly incrementing beyond the length of the packet, which would cause subsequent calls to `copy_n` in `GetNumber` to fail because data was out of bounds.