### PR TITLE
Add mitigations for connection spam

### DIFF
--- a/config/server.ini
+++ b/config/server.ini
@@ -14,7 +14,7 @@ Host = 0.0.0.0
 Port = 8078
 
 ## MaxConnections (number)
-# The maximum number of connections the server will open
+# The maximum number of connections the server will allow at once
 MaxConnections = 300
 
 ## ListenBacklog (number)
@@ -38,6 +38,15 @@ IPReconnectLimit = 10s
 # The maximum numbers of connections one computer can open (still evadeable)
 # 0 for unlimited
 MaxConnectionsPerPC = 1
+
+## HangupDelay (number)
+# Maximum number of seconds before closing uninitialized clients
+HangupDelay = 10s
+
+## QuietConnectionErrors (boolean)
+# Delay and de-duplicate connection errors
+# Can help avoid log spam during attacks
+QuietConnectionErrors = false
 
 ## MaxLoginAttempts (number)
 # Maximum number of login attempts before disconnecting

--- a/src/eoclient.cpp
+++ b/src/eoclient.cpp
@@ -57,6 +57,7 @@ void EOClient::Initialize()
 	this->version = 0;
 	this->needpong = false;
 	this->login_attempts = 0;
+	this->start = Timer::GetTime();
 }
 
 void EOClient::LogPacket(PacketFamily family, PacketAction action, size_t sz, const char * const actionStr)

--- a/src/eoclient.hpp
+++ b/src/eoclient.hpp
@@ -109,6 +109,7 @@ class EOClient : public Client
 		bool needpong;
 		int hdid;
 		ClientState state;
+		double start;
 		int login_attempts;
 
 		ActionQueue queue;

--- a/src/eoserv_config.cpp
+++ b/src/eoserv_config.cpp
@@ -38,8 +38,10 @@ void eoserv_config_validate_config(Config& config)
 	eoserv_config_default(config, "ListenBacklog"      , 50);
 	eoserv_config_default(config, "MaxPlayers"         , 200);
 	eoserv_config_default(config, "MaxConnectionsPerIP", 3);
-	eoserv_config_default(config, "IPReconnectLimit"   , 10);
+	eoserv_config_default(config, "IPReconnectLimit"   , 10.0);
 	eoserv_config_default(config, "MaxConnectionsPerPC", 1);
+	eoserv_config_default(config, "HangupDelay"        , 10.0);
+	eoserv_config_default(config, "QuietConnectionErrors", false);
 	eoserv_config_default(config, "MaxLoginAttempts"   , 3);
 	eoserv_config_default(config, "LoginQueueSize"     , 10);
 	eoserv_config_default(config, "CheckVersion"       , true);

--- a/src/eoserver.hpp
+++ b/src/eoserver.hpp
@@ -13,6 +13,7 @@
 #include "fwd/database.hpp"
 #include "fwd/eoclient.hpp"
 #include "fwd/sln.hpp"
+#include "fwd/timer.hpp"
 #include "fwd/world.hpp"
 
 #include "socket.hpp"
@@ -24,14 +25,23 @@
 void server_ping_all(void *server_void);
 void server_pump_queue(void *server_void);
 
+struct ConnectionLogEntry
+{
+	double last_connection_time = 0.0;
+	double last_rejection_time = 0.0;
+	int rejections = 0;
+};
+
 /**
  * A server which accepts connections and creates EOClient instances from them
  */
 class EOServer : public Server
 {
 	private:
-		std::unordered_map<IPAddress, double, std::hash<IPAddress>> connection_log;
+		std::unordered_map<IPAddress, ConnectionLogEntry> connection_log;
 		void Initialize(std::shared_ptr<DatabaseFactory> databaseFactory, const Config &eoserv_config, const Config &admin_config);
+
+		TimeEvent* ping_timer = nullptr;
 
 	protected:
 		virtual Client *ClientFactory(const Socket &);
@@ -41,12 +51,20 @@ class EOServer : public Server
 		double start;
 		SLN *sln;
 
+		bool QuietConnectionErrors = false;
+		double HangupDelay = 10.0;
+
+		void UpdateConfig();
+
 		EOServer(IPAddress addr, unsigned short port, std::shared_ptr<DatabaseFactory> databaseFactory, const Config &eoserv_config, const Config &admin_config) : Server(addr, port)
 		{
 			this->Initialize(databaseFactory, eoserv_config, admin_config);
 		}
 
 		void Tick();
+
+		void RecordClientRejection(const IPAddress& ip, const char* reason);
+		void CleanupConnectionLog();
 
 		~EOServer();
 };

--- a/src/handlers/Connection.cpp
+++ b/src/handlers/Connection.cpp
@@ -24,6 +24,8 @@ void Connection_Accept(EOClient *client, PacketReader &reader)
 		client->Close();
 		return;
 	}
+
+	client->MarkAccepted();
 }
 
 // Ping reply

--- a/src/handlers/Init.cpp
+++ b/src/handlers/Init.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <ctime>
 #include <stdexcept>
 #include <string>
@@ -77,7 +78,9 @@ void Init_Init(EOClient *client, PacketReader &reader)
 
 		if (max_per_pc != 0 && pc_connections > max_per_pc)
 		{
-			Console::Wrn("Connection from %s was rejected (too many connections from this PC: %08x)", static_cast<std::string>(client->GetRemoteAddr()).c_str(), client->hdid);
+			char errbuf[64];
+			std::snprintf(errbuf, sizeof errbuf, "too many connections from this PC: %08x", client->hdid);
+			client->server()->RecordClientRejection(client->GetRemoteAddr(), errbuf);
 			client->Close(true);
 		}
 	}

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -716,15 +716,6 @@ Client *Server::Poll()
 #endif // WIN32
 	if ((newsock = accept(this->impl->sock, reinterpret_cast<sockaddr *>(&sin), &addrsize)) == INVALID_SOCKET)
 	{
-		if (this->clients.size() >= this->maxconn)
-		{
-#ifdef WIN32
-			closesocket(newsock);
-#else // WIN32
-			close(newsock);
-#endif // WIN32
-		}
-
 		return 0;
 	}
 #ifdef WIN32
@@ -733,6 +724,41 @@ Client *Server::Poll()
 #else // WIN32
 	fcntl(this->impl->sock, F_SETFL, 0);
 #endif // WIN32
+
+	// Close uninitialized connections to make room for new ones
+	if (this->clients.size() >= this->maxconn)
+	{
+		for (auto it = this->clients.begin();
+		 it != this->clients.end() && this->clients.size() >= this->maxconn;
+		 ++it)
+		{
+			Client* client = *it;
+			if (!client->accepted)
+			{
+				client->Close(true);
+#ifdef WIN32
+				closesocket(client->impl->sock);
+#else // WIN32
+				close(client->impl->sock);
+#endif // WIN32
+				delete client;
+				it = this->clients.erase(it);
+				if (it == this->clients.end())
+					break;
+			}
+		}
+
+		// If the server truly is full, fail the connection
+		if (this->clients.size() >= this->maxconn)
+		{
+#ifdef WIN32
+			closesocket(newsock);
+#else // WIN32
+			close(newsock);
+#endif // WIN32
+			return 0;
+		}
+	}
 
 	newclient = this->ClientFactory(Socket(newsock, sin));
 	newclient->SetRecvBuffer(this->recv_buffer_max);
@@ -921,8 +947,6 @@ std::vector<Client *> *Server::Select(double timeout)
 
 void Server::BuryTheDead()
 {
-	// TODO: Optimize
-	restart_loop:
 	UTIL_IFOREACH(this->clients, it)
 	{
 		Client *client = *it;
@@ -935,8 +959,9 @@ void Server::BuryTheDead()
 			close(client->impl->sock);
 #endif // WIN32
 			delete client;
-			this->clients.erase(it);
-			goto restart_loop;
+			it = this->clients.erase(it);
+			if (it == this->clients.end())
+				break;
 		}
 	}
 }

--- a/src/socket.hpp
+++ b/src/socket.hpp
@@ -229,6 +229,7 @@ class Client
 	protected:
 		Server *server;
 		bool connected;
+		bool accepted = false;
 		std::time_t closed_time;
 		std::time_t connect_time;
 
@@ -266,6 +267,9 @@ class Client
 		bool DoSend();
 
 		bool Select(double timeout);
+
+		bool Accepted() const { return accepted; }
+		void MarkAccepted() { accepted = true; }
 
 		virtual bool Connected() const;
 		IPAddress GetRemoteAddr() const;

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -1300,6 +1300,7 @@ void World::Rehash()
 
 	this->UpdateConfig();
 	this->LoadHome();
+	this->server->UpdateConfig();
 
 	UTIL_FOREACH(this->maps, map)
 	{


### PR DESCRIPTION
- Adds HangupDelay config option (default 10 seconds) to automatically close uninitialized connections
- Adds QuietConnectionErrors config option (default off) to group together repeated connection failure log lines from the same IP
- Allows adjusting MaxConnections and PingRate via $rehash
- Fixes the MaxConnections check on client accept
- Removes the "too many connections to server" connection failure on init
- Closes uninitialized clients, starting from the oldest, to make room for new clients if possible