### PR TITLE
Change Docker image to use Alpine base image and nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
-FROM ubuntu:22.04
+FROM alpine:3.17.2
 
 COPY scripts/install-deps.sh /tmp
-RUN mkdir /etheos
 COPY install/ /etheos
-RUN rm -rf /etheos/config_local /etheos/test
 WORKDIR /etheos
 
-RUN apt-get update && apt-get install -y curl gnupg2 &&\
+# curl/gnupg :: required for package installs in install-deps
+# bash :: required to run install-deps
+# gcompat :: compatibility layer for glibc in Alpine Linux. See: https://wiki.alpinelinux.org/wiki/Running_glibc_programs
+RUN rm -rf /etheos/config_local /etheos/test &&\
+    apk add --update --no-cache curl gnupg bash gcompat &&\
     /tmp/install-deps.sh --skip-cmake --skip-json &&\
-    apt-get clean && rm /tmp/install-deps.sh
+    rm /tmp/install-deps.sh &&\
+    addgroup -g 8078 -S etheos && adduser -S -D -u 8078 -h /etheos etheos etheos &&\
+    chown -R etheos:etheos /etheos
+
+USER etheos:etheos
+
 EXPOSE 8078
 
-CMD [ "./etheos" ]
+CMD [ "/etheos/etheos" ]

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -104,8 +104,7 @@ if [ "$SKIPSQLITE" == "false" ]; then
     elif [ "$PLATFORM_NAME" == "rhel" ]; then
         PACKAGES="$PACKAGES sqlite-devel"
     elif [ "$PLATFORM_NAME" == "alpine" ]; then
-        #echo 'http://dl-cdn.alpinelinux.org/alpine/v3.15/main' >> /etc/apk/repositories
-        PACKAGES="$PACKAGES sqlite-dev" #==3.36.0-r0"
+        PACKAGES="$PACKAGES sqlite-dev"
     fi
 fi
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -49,20 +49,29 @@ fi
 set +e
 
 PLATFORM_NAME=$(grep -qi ubuntu /etc/os-release && echo 'ubuntu')
-PLATFORM_VERSION=$(grep -oPi 'VERSION_ID=\K"(.+)"' /etc/os-release | sed -e 's/"//g')
 if [ -z "$PLATFORM_NAME" ]; then
     PLATFORM_NAME=$(egrep -qi "(rhel|centos)" /etc/os-release && echo 'rhel')
 
     if [ -z "$PLATFORM_NAME" ]; then
-        >&2 echo "Unsupported platform detected! Use Ubuntu/rhel"
-        exit -1
+        PLATFORM_NAME=$(grep -qi alpine /etc/os-release && echo 'alpine')
+
+        if [ -z "$PLATFORM_NAME" ]; then
+            >&2 echo "Unsupported platform detected! Use Ubuntu/rhel"
+            exit -1
+        else
+            PLATFORM_VERSION=$(cat /etc/alpine-release)
+        fi
     fi
 fi
 
-SUPPORTED_VERSIONS=" 14.04 16.04 18.04 18.10 19.04 20.04 22.04 6 7 8 "
-VERSION_IS_SUPPORTED=$(echo $SUPPORTED_VERSIONS | grep -oP " $PLATFORM_VERSION ")
 if [ -z "$PLATFORM_VERSION" ]; then
-    >&2 echo "Unable to detect platform version! Check that /etc/os-release has a VERSION_ID= set."
+    PLATFORM_VERSION=$(grep -oPi 'VERSION_ID=\K"(.+)"' /etc/os-release | sed -e 's/"//g')
+fi
+
+SUPPORTED_VERSIONS=" 14.04 16.04 18.04 18.10 19.04 20.04 22.04 6 7 8 3.17.2 "
+VERSION_IS_SUPPORTED=$(echo "$SUPPORTED_VERSIONS" | grep -oe " $PLATFORM_VERSION ")
+if [ -z "$PLATFORM_VERSION" ]; then
+    >&2 echo "Unable to detect platform version! Check that /etc/os-release has a VERSION_ID= set (/etc/alpine-release for Alpine Linux)."
     exit -1
 elif [ -z "$VERSION_IS_SUPPORTED" ]; then
     >&2 echo "Platform version is unsupported! Detected version: $PLATFORM_VERSION"
@@ -84,6 +93,8 @@ if [ "$SKIPMARIADB" == "false" ]; then
         PACKAGES="$PACKAGES libmariadb-dev"
     elif [ "$PLATFORM_NAME" == "rhel" ]; then
         PACKAGES="$PACKAGES mariadb-devel"
+    elif [ "$PLATFORM_NAME" == "alpine" ]; then
+        PACKAGES="$PACKAGES mariadb-dev"
     fi
 fi
 
@@ -92,6 +103,9 @@ if [ "$SKIPSQLITE" == "false" ]; then
         PACKAGES="$PACKAGES libsqlite3-dev"
     elif [ "$PLATFORM_NAME" == "rhel" ]; then
         PACKAGES="$PACKAGES sqlite-devel"
+    elif [ "$PLATFORM_NAME" == "alpine" ]; then
+        #echo 'http://dl-cdn.alpinelinux.org/alpine/v3.15/main' >> /etc/apk/repositories
+        PACKAGES="$PACKAGES sqlite-dev" #==3.36.0-r0"
     fi
 fi
 
@@ -109,6 +123,19 @@ if [ "$SKIPSQLSERVER" == "false" ]; then
         fi
         yum remove -y unixODBC-utf16 unixODBC-utf16-devel > /dev/null
         PACKAGES="$PACKAGES msodbcsql17 unixODBC-devel"
+    elif [ "$PLATFORM_NAME" == "alpine" ]; then
+        # From: https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver16&tabs=ubuntu18-install%2Calpine17-install%2Cdebian8-install%2Credhat7-13-install%2Crhel7-offline#17
+
+        # Download the desired package(s)
+        curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.10.2.1-1_amd64.apk
+
+        # Verify signature
+        curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.10.2.1-1_amd64.sig
+        curl https://packages.microsoft.com/keys/microsoft.asc  | gpg --import -
+        gpg --verify msodbcsql17_17.10.2.1-1_amd64.sig msodbcsql17_17.10.2.1-1_amd64.apk
+
+        # Install the package(s)
+        apk add --allow-untrusted msodbcsql17_17.10.2.1-1_amd64.apk
     fi
 fi
 
@@ -125,9 +152,14 @@ if [ "$PLATFORM_NAME" == "ubuntu" ]; then
 elif [ "$PLATFORM_NAME" == "rhel" ]; then
     yum makecache fast > /dev/null
     ACCEPT_EULA=Y yum install -y $PACKAGES
+elif [ "$PLATFORM_NAME" == "alpine" ]; then
+    ACCEPT_EULA=Y apk add --no-cache --update $PACKAGES
 fi
 
 if [ "$SKIPCMAKE" == "false" ]; then
+#
+# NOTE: ALPINE SUPPORT WAS NOT ADDED FOR CMAKE
+#
     echo "Installing cmake..."
     if [ "$PLATFORM_NAME" == "ubuntu" ]; then
         apt-get remove -y cmake > /dev/null

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -386,13 +386,24 @@ void Database::Connect(Database::Engine type, const std::string& host, unsigned 
 		case SQLite:
 			if (sqlite3_libversion_number() != SQLITE_VERSION_NUMBER)
 			{
-				Console::Err("SQLite library version mismatch! Please recompile EOSERV with the correct SQLite library.");
-				Console::Err("  Expected version: %s", SQLITE_VERSION);
-				Console::Err("  Library version:  %s", sqlite3_libversion());
+				if (sqlite3_libversion_number() > SQLITE_VERSION_NUMBER)
+				{
+					Console::Wrn("SQLite library runtime version is greater than the library version that etheos was compiled with.");
+					Console::Wrn("  Installed version: %s", sqlite3_libversion());
+					Console::Wrn("  etheos version:    %s", SQLITE_VERSION);
+					Console::Wrn("This could cause crashes with SQLite calls.");
+				}
+				else
+				{
+					Console::Err("SQLite library version mismatch! Please recompile EOSERV with the correct SQLite library.");
+					Console::Err("  Expected version: %s", SQLITE_VERSION);
+					Console::Err("  Library version:  %s", sqlite3_libversion());
 #ifdef WIN32
-				Console::Err("Make sure EOSERV is using the correct version of sqlite3.dll");
+					Console::Err("Make sure EOSERV is using the correct version of sqlite3.dll");
 #endif // WIN32
-				throw Database_OpenFailed("SQLite library version mismatch");
+
+					throw Database_OpenFailed("SQLite library version mismatch");
+				}
 			}
 
 			if (sqlite3_open(host.c_str(), &this->impl->sqlite_handle) != SQLITE_OK)

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -389,15 +389,15 @@ void Database::Connect(Database::Engine type, const std::string& host, unsigned 
 				if (sqlite3_libversion_number() > SQLITE_VERSION_NUMBER)
 				{
 					Console::Wrn("SQLite library runtime version is greater than the library version that etheos was compiled with.");
-					Console::Wrn("  Installed version: %s", sqlite3_libversion());
-					Console::Wrn("  etheos version:    %s", SQLITE_VERSION);
-					Console::Wrn("This could cause crashes with SQLite calls.");
+					Console::Wrn("  Compiled version: %s", SQLITE_VERSION);
+					Console::Wrn("  Runtime version:  %s", sqlite3_libversion());
+					Console::Wrn("This could cause issues if you have modified etheos to use non-stable sqlite3 API calls.");
 				}
 				else
 				{
-					Console::Err("SQLite library version mismatch! Please recompile EOSERV with the correct SQLite library.");
-					Console::Err("  Expected version: %s", SQLITE_VERSION);
-					Console::Err("  Library version:  %s", sqlite3_libversion());
+					Console::Err("SQLite library runtime version is incompatible with the library version that etheos was compiled with.");
+					Console::Err("  Compiled version: %s", SQLITE_VERSION);
+					Console::Err("  Runtime version:  %s", sqlite3_libversion());
 #ifdef WIN32
 					Console::Err("Make sure EOSERV is using the correct version of sqlite3.dll");
 #endif // WIN32


### PR DESCRIPTION
Adds Alpine 3.17.2 support to dependency install script, with the exception of CMake installation