### PR TITLE
Fix double-free bug in weddings

### DIFF
--- a/src/wedding.cpp
+++ b/src/wedding.cpp
@@ -61,7 +61,7 @@ void Wedding::StopTimer()
 {
 	if (this->tick_timer)
 	{
-		delete this->tick_timer;
+		this->map->world->timer.Unregister(this->tick_timer);
 		this->tick_timer = nullptr;
 	}
 }


### PR DESCRIPTION
Deleting a timer event in the middle of `Timer::Tick` is probably a bad idea.

I have not tested this change.